### PR TITLE
Fix method call typo in merged_axis plugin.

### DIFF
--- a/action_plugins/merged_axis/__init__.py
+++ b/action_plugins/merged_axis/__init__.py
@@ -118,7 +118,7 @@ class MergeAxisEntryWidget(QtWidgets.QDockWidget):
         self.operation_selector.addItem("Maximum", gremlin.types.MergeAxisOperation.Maximum)
         self.operation_selector.addItem("Sum",gremlin.types.MergeAxisOperation.Sum)
         self.operation_selector.currentIndexChanged.connect(
-            lambda x: self.change_cb()
+            lambda x: self._change_cb()
         )
 
         self.operation_container_widget = QtWidgets.QWidget()


### PR DESCRIPTION
Fix an exception thrown when trying to use merged_axis.