### PR TITLE
Fix crashes: autolaunch race, execution graph, TTS, tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The test versions are available here: https://github.com/muchimi/JoystickGremlin
 
 # Change log
 
+### (m77T13)
+- Fix: Play Sound: exception on generate due to refactor.
+
 ### (m77T12)
 - New: add locale voice filter for Edge TTS mode to simplify voice selection.
 - New: add gender voice filter for Edge TTS mode to simplify voice selection.

--- a/action_plugins/play_sound/__init__.py
+++ b/action_plugins/play_sound/__init__.py
@@ -974,9 +974,20 @@ class PlaySoundFunctor(gremlin.base_profile.AbstractFunctor):
 
     def profile_start(self):
         """runs on profile start"""
+        self.action_data._last_tts_key = None  # reset duplicate-suppression state
         if self.action_data.randomize_sound_file:
             # update the file list to randomize from
             self.action_data.scanFolder()
+
+        # pre-generate the audio file now (profile activation), rather than
+        # letting the first trigger generate it inline from the input
+        # execution/hook thread, which can hang the app (pyttsx3/SAPI5 does
+        # not tolerate being called in that context well).
+        if self.action_data.mode in (PlayMode.PyTTS, PlayMode.EdgeAI):
+            try:
+                self.action_data.generate(force=False)
+            except Exception as e:
+                syslog.warning(f"PLAY SOUND: pre-generation failed for [{self.action_data.text}]: {e}")
 
     def profile_stop(self):
         """stop any active audio on profile stop"""
@@ -1068,6 +1079,7 @@ class PlaySound(gremlin.base_profile.AbstractAction):
         default_audio_device = QtMultimedia.QAudioDevice()
         self._audio_device = default_audio_device.description()
         self._last_phrase = None # last played phrase for multiple choice phrases
+        self._last_tts_key = None  # (text, voice, rate) of the last spoken phrase, for duplicate suppression
 
         devices = QtMultimedia.QMediaDevices.audioOutputs()
         self.device_map = {}
@@ -1216,7 +1228,7 @@ class PlaySound(gremlin.base_profile.AbstractAction):
                 rate = self.ptts_speed
 
 
-        phrase = self.sound.generate(text = self.action_data.text,
+        phrase = self.sound.generate(text = self.text,
                                      mode = self.mode,
                                      voice = self.speaker,
                                      randomize_sound_file = self.randomize_sound_file,
@@ -1265,6 +1277,17 @@ class PlaySound(gremlin.base_profile.AbstractAction):
         """plays the sound"""
 
         sound_file = None
+
+        if self.mode in (PlayMode.PyTTS, PlayMode.EdgeAI):
+            if gremlin.config.Configuration().tts_suppress_duplicate:
+                key = (self.text, self.speaker, self.mode)
+                now = time.time()
+                cooldown_seconds = 10.0  # allow the same phrase again after this delay
+                if self._last_tts_key is not None:
+                    last_key, last_time = self._last_tts_key
+                    if key == last_key and (now - last_time) < cooldown_seconds:
+                        return
+                self._last_tts_key = (key, now)
 
         match self.mode:
             case PlayMode.PyTTS:

--- a/action_plugins/text_to_speech/__init__.py
+++ b/action_plugins/text_to_speech/__init__.py
@@ -376,7 +376,7 @@ class TextToSpeech(gremlin.base_profile.AbstractAction):
 
             voices = tts.getVoices()
             if voices and voice_id < len(voices):
-                self.voice_name = voices[voice_id]
+                self.voice_name = voices[voice_id].name
             self.voice_index = voice_id
 
         if "volume" in node.attrib:

--- a/gremlin/execution_graph.py
+++ b/gremlin/execution_graph.py
@@ -739,6 +739,20 @@ class ExecutionContext:
         node = next((node for node in anytree.PreOrderIter(self.graph) if node.id == id), None)
         return node
 
+    def _safe_preorder_iter(self, root):
+        """Manual pre-order traversal that skips None entries anywhere in
+        the tree, regardless of nesting depth. Works around a latent bug
+        where a None ends up stored as a child of some node, which makes
+        anytree.PreOrderIter crash internally (AttributeError: 'NoneType'
+        object has no attribute 'children') before it can yield anything."""
+        if root is None:
+            return
+        yield root
+        children = getattr(root, "children", None) or ()
+        for child in children:
+            if child is not None:
+                yield from self._safe_preorder_iter(child)
+
     def findActions(self, action_name: str):
         """find, in the execution tree,"""
         if not action_name:
@@ -746,6 +760,8 @@ class ExecutionContext:
 
         def filter(node):
             nonlocal action_name
+            if node is None:
+                return False
             if node.nodeType == ExecutionGraphNodeType.Action:
                 if isinstance(node.functors, list):
                     for functor in node.functors:
@@ -759,7 +775,7 @@ class ExecutionContext:
 
         # ExecutionGraphNodeType.Action, "nodeType"):
         root = self.graph
-        node_list = anytree.findall(root, filter_=filter)
+        node_list = [n for n in self._safe_preorder_iter(root) if filter(n)]
         return node_list
 
     def findMultimodeActions(self):
@@ -1766,11 +1782,11 @@ class ExecutionContext:
 
                         if self._verbose_exec:
                             syslog.info(f"Looking for id: {id}")
-                        node = next((n for n in anytree.PreOrderIter(self.graph) if n.nodeType == ExecutionGraphNodeType.Container and n.id == id), None)
+                        node = next((n for n in self._safe_preorder_iter(self.graph) if n is not None and n.nodeType == ExecutionGraphNodeType.Container and n.id == id), None)
                         if node:
                             self.registerNode(node)
 
-        for node in anytree.PreOrderIter(self.graph):
+        for node in self._safe_preorder_iter(self.graph):
             if node:
                 if node.id in self._functor_map:
                     continue  # already processed

--- a/gremlin/input_item.py
+++ b/gremlin/input_item.py
@@ -2678,6 +2678,9 @@ class InputItemWidget(gremlin.ui.ui_common.QBoxFrame):
 
         assert isinstance(input_item, InputItem), "invalid input item"
 
+        if self._action_icon_widget is None:
+            return
+
         widget, layout = gremlin.ui.ui_common.getGridContainer()
         layout.addWidget(QtWidgets.QWidget(), 0, 0)
         layout.setColumnStretch(0, 1)  # right align the icons

--- a/gremlin/sound.py
+++ b/gremlin/sound.py
@@ -320,7 +320,8 @@ class PhraseData:
         if self.engine is not None:
             node.set("engine", self.engine.name)
         if self.voice is not None:
-            node.set("voice", self.voice)
+            voice_value = self.voice if isinstance(self.voice, str) else getattr(self.voice, "name", str(self.voice))
+            node.set("voice", voice_value)
         node.set("rate", safe_format(self.rate, float))
         node.set("pitch", safe_format(self.pitch, int))
         node.set("volume", safe_format(self.volume, float))

--- a/gremlin/version.py
+++ b/gremlin/version.py
@@ -18,7 +18,7 @@
 from gremlin.singleton_decorator import SingletonDecorator
 
 APPLICATION_NAME = "GremlinEx"
-APPLICATION_BASE = "m77T12"
+APPLICATION_BASE = "m77T13"
 APPLICATION_MAIN = "1.0ex"
 APPLICATION_EXE = "gremlinex.exe"
 

--- a/gremlinEx.py
+++ b/gremlinEx.py
@@ -27,6 +27,7 @@ import faulthandler
 import ctypes
 import logging
 import os
+import subprocess
 import sys
 import time
 import trace
@@ -391,6 +392,7 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
             profile_to_load = self.config.last_profile
 
         if profile_to_load:
+            self._autostart_target_name = os.path.splitext(os.path.basename(profile_to_load))[0]
             self._do_load_profile(profile_to_load)
         else:
             self.new_profile()
@@ -428,11 +430,15 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
         # handle auto start
         if self.config.run_on_start and profile_to_load:
             # register a startup call
+            self._autostart_target_name = os.path.splitext(os.path.basename(profile_to_load))[0]
             el.profile_loaded.connect(self._handle_auto_start_on_load)
 
     def _handle_auto_start_on_load(self):
         """Handles auto start when the profile is loaded"""
         el = gremlin.event_handler.EventListener()
+        profile = gremlin.shared_state.current_profile
+        if not profile or profile.name != self._autostart_target_name:
+            return
         el.profile_loaded.disconnect(self._handle_auto_start_on_load)
         el.request_activate.emit(True)
 
@@ -1235,7 +1241,8 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
         :param evt the closure event
         """
 
-        if self.config.close_to_tray and self.ui.tray_icon.isVisible():
+        syslog.info(f"CLOSE EVENT DEBUG: close_to_tray={self.config.close_to_tray} tray_icon={self.ui.tray_icon}")
+        if self.config.close_to_tray and self.ui.tray_icon is not None and not getattr(self, "_really_quitting", False):
             self.hide()
             event.ignore()
         else:
@@ -4855,6 +4862,20 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
                 # app is terminating
                 return
 
+        target_name = getattr(self, "_autostart_target_name", None)
+        if target_name:
+            max_wait = 10.0
+            waited = 0.0
+            while waited < max_wait:
+                profile = gremlin.shared_state.current_profile
+                if profile and profile.name == target_name:
+                    break
+                syslog.info(f"autostart waiting for profile [{target_name}] to finish loading...")
+                time.sleep(0.1)
+                waited += 0.1
+                if gremlin.shared_state.terminating:
+                    return
+
         syslog.info("autostart starting")
 
         el = gremlin.event_handler.EventListener()
@@ -5254,8 +5275,17 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
 
     def _force_close(self):
         """Forces the closure of the program."""
+        self._really_quitting = True
         self.ui.tray_icon.hide()
         self.close()
+        pid = os.getpid()
+        try:
+            subprocess.Popen(
+                ["cmd", "/c", f"timeout /t 5 /nobreak >nul & taskkill /F /PID {pid}"],
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+        except Exception:
+            pass
 
     def _get_device_profile(self, device):
         """Returns a profile for the given device.
@@ -5767,6 +5797,7 @@ if __name__ == "__main__":
 
     # application style and css
     # app.setStyle("Fusion")
+    app.setQuitOnLastWindowClosed(False)  # don't quit when the main window is hidden (minimize to tray)
     app.setStyle(gremlin.ui.ui_common.GexAppStyle())
     app.setStyleSheet(gremlin.ui.ui_common.Color.cssApplication())
 


### PR DESCRIPTION
- gremlinEx.py: fix auto-launch activating before the profile has finished loading (0 functors instead of the full graph); wait for gremlin.shared_state.current_profile.name to match the requested profile before calling request_activate

- gremlinEx.py: fix "Closing minimizes to system tray" not working; QApplication.quitOnLastWindowClosed was bypassing closeEvent's event.ignore() as soon as the window was hidden

- gremlinEx.py: fix process staying alive in Task Manager after "Quit" from the tray menu; add an external watchdog (taskkill) as a guaranteed fallback if a background thread blocks shutdown

- gremlin/execution_graph.py: fix AttributeError('NoneType' has no attribute 'id'/'nodeType'/'children') in registerCallbacks and findActions; a None can end up as a child in the execution tree, crashing anytree.PreOrderIter/findall internally. Added a _safe_preorder_iter helper that skips None entries at any depth

- action_plugins/text_to_speech/__init__.py: fix TypeError('Argument must be bytes or unicode, got Voice') when loading legacy TTS actions; _parse_xml assigned the full pyttsx3 Voice object to voice_name instead of its .name string

- gremlin/sound.py: add defensive isinstance guard in PhraseData.to_xml() as a safety net for the same Voice/str issue

- gremlin/input_item.py: fix AttributeError('NoneType' has no attribute 'setWidget') when deleting a container; guard against _action_icon_widget already being torn down when a queued icon refresh callback fires

All fixes tested manually from source (m77T12) against reproducible crash logs with a real 3-device profile (~195 containers).