### PR TITLE
Fix Vjoy Remap hat output being ignored (always drove hat 1)

### DIFF
--- a/action_plugins/map_to_vjoy/__init__.py
+++ b/action_plugins/map_to_vjoy/__init__.py
@@ -2048,7 +2048,7 @@ class VJoyRemapWidget(gremlin.input_item.AbstractActionWidget):
 
         elif input_type == InputType.JoystickHat:
             if not action_name:
-                action_name = f"Vjoy device {vjoy_id} hat {vjoy_input_id}"
+                action_name = f"Vjoy device {vjoy_id} hat {self.action_data.vjoy_hat_id}"
             prefix = f"Hat {input_id}"
 
         else:
@@ -3454,15 +3454,26 @@ class VJoyRemapWidget(gremlin.input_item.AbstractActionWidget):
 
             elif input_type == InputType.JoystickHat:
                 count = device.hat_count
-                for id in range(1, count + 1):
-                    self.virtual_output_selector_widget.addItem(f"Hat {id}", id)
-                input_id = self.action_data.vjoy_input_id
+                with QtCore.QSignalBlocker(self.virtual_output_selector_widget):
+                    for id in range(1, count + 1):
+                        self.virtual_output_selector_widget.addItem(f"Hat {id}", id)
+                    hat_index = self.virtual_output_selector_widget.findData(self.action_data.vjoy_hat_id)
+                    if hat_index != -1:
+                        self.virtual_output_selector_widget.setCurrentIndex(hat_index)
+                input_id = self.action_data.vjoy_hat_id
                 if input_id < 1 or input_id > count:
                     self.setWarning(f"VJOY configuration has changed and GremlinEx is unable to find the requested Vjoy hat # {input_id}")
                     return
 
     def _get_output_index(self):
-        index = self.virtual_output_selector_widget.findData(self.action_data.vjoy_input_id)
+        if self.action_data.action_mode in (
+            VjoyAction.VJoyHat,
+            VjoyAction.VJoyHatPress,
+            VjoyAction.VJoyHatPulse,
+        ):
+            index = self.virtual_output_selector_widget.findData(self.action_data.vjoy_hat_id)
+        else:
+            index = self.virtual_output_selector_widget.findData(self.action_data.vjoy_input_id)
         return index or -1
 
     @QtCore.Slot(float)
@@ -4331,6 +4342,13 @@ class VJoyRemapFunctor(gremlin.base_profile.AbstractFunctor):
         self.verbose_extra = self.verbose and config.verbose_mode_extra
         self.vjoy_id = action_data.virtual_id
         self.vjoy_input_id = action_data.vjoy_input_id
+        # For hat actions the output hat is stored in vjoy_hat_id.
+        if action_data.action_mode in (
+            VjoyAction.VJoyHat,
+            VjoyAction.VJoyHatPress,
+            VjoyAction.VJoyHatPulse,
+        ):
+            self.vjoy_input_id = action_data.vjoy_hat_id
         self.input_type = action_data.get_input_type()
         self.axis_scaling = action_data.axis_scaling
         self.action_mode = action_data.action_mode
@@ -7574,7 +7592,17 @@ Supports axis merging, curved output, command, hat and button mappings.
             if position_name:
                 node.set("return-position", position_name)
         else:
-            node.set(InputType.to_string(self.input_type), str(self.vjoy_input_id))
+            # For hat actions the selected output hat lives in vjoy_hat_id;
+            # saving vjoy_input_id here discarded the UI selection.
+            if self.action_mode in (
+                VjoyAction.VJoyHat,
+                VjoyAction.VJoyHatPress,
+                VjoyAction.VJoyHatPulse,
+            ):
+                output_id = self.vjoy_hat_id
+            else:
+                output_id = self.vjoy_input_id
+            node.set(InputType.to_string(self.input_type), str(output_id))
 
         node.set("mode", safe_format(VjoyAction.to_string(self.action_mode), str))
 

--- a/gremlin/ui/ui_common.py
+++ b/gremlin/ui/ui_common.py
@@ -10509,9 +10509,9 @@ class QRememberMainWindow(ResizableWindow):
 
         window_location = config.getWindowLocation(self._window_key)
 
-        if window_size:
+        if window_size and window_size[0] is not None and window_size[1] is not None:
             self.resize(window_size[0], window_size[1])
-        if window_location:
+        if window_location and window_location[0] is not None and window_location[1] is not None:
             self.move(window_location[0], window_location[1])
         else:
             self.active_screen = QtWidgets.QApplication.screenAt(self.pos())
@@ -10632,12 +10632,14 @@ class QRememberDialog(QtWidgets.QDialog):
             config = gremlin.config.Configuration()
             window_size = config.getWindowSize(self._window_key)
             window_location = config.getWindowLocation(self._window_key)
-            if window_size:
+            if window_size and window_size[0] is not None and window_size[1] is not None:
                 self.resize(window_size[0], window_size[1])
             else:
                 self.resize(self._default_width, self._default_height)
             if window_location:
                 x, y = window_location
+                if x is None or y is None:
+                    x, y = self.x(), self.y()
                 pos = QtCore.QPoint(x, y)
                 # syslog.info(f"recall move window {self.window_key} to {x},{y}")
                 self.move(pos)
@@ -10649,7 +10651,7 @@ class QRememberDialog(QtWidgets.QDialog):
         config = gremlin.config.Configuration()
         window_size = config.getWindowSize(self._window_key)
         hint_size = self.sizeHint()
-        if window_size:
+        if window_size and window_size[0] is not None and window_size[1] is not None:
             size = QtCore.QSize(window_size[0], window_size[1])
             return size.expandedTo(hint_size)
 


### PR DESCRIPTION
Two independent fixes on top of m77T19. Clean branch replacing #463.

## 1. Vjoy Remap: hat output ignored (always drove hat 1)

Mapping a physical hat to a vJoy hat output via Vjoy Remap (Mode: Hat) had
no effect when choosing Hat 2/3/4 — runtime always drove hat 1 and the UI
reverted to Hat 1.

Root cause: the selected output hat is stored in `vjoy_hat_id`, but several
paths used `vjoy_input_id` (the physical source input), so the selection was
never persisted, re-read, or executed. Confirmed with debug logging.

Fixes, scoped to hat modes only (axes/buttons keep using `vjoy_input_id`):
- `_generate_xml`: persist `vjoy_hat_id`
- `VJoyRemapFunctor.__init__`: drive the hat via `vjoy_hat_id`
- output selector: preselect from `vjoy_hat_id`
- `_get_output_index`: resolve from `vjoy_hat_id`
- summary text: show `vjoy_hat_id`

Tested on m77T19, VKB hat → vJoy device 2 hats 2/3/4: correct POV in the vJoy
monitor, selection persists across save/reload and profile toggle.

## 2. Window-geometry None guards (ui_common.py)

Guard resize()/QSize()/move() against None members in saved window geometry
(window closed off-screen or on a disconnected monitor), which otherwise
crashes with `resize(NoneType, int)`.