### PR TITLE
Add direct HID path for Virpil LED updates

### DIFF
--- a/action_plugins/virpil_led/__init__.py
+++ b/action_plugins/virpil_led/__init__.py
@@ -1026,6 +1026,12 @@ class VirpilActionFunctor(gremlin.base_profile.AbstractFunctor):
             self._pulse_timer = None
             if self._valid:
                 self._turn_off_leds()
+        try:
+            import gremlin.virpil_led_hid
+
+            gremlin.virpil_led_hid.VirpilLedHid().close_all()
+        except Exception:
+            pass
 
 
     def process_event(self, event: gremlin.event_handler.Event, value: gremlin.actions.Value, extra_data=None):
@@ -1153,28 +1159,50 @@ class VirpilAction(gremlin.input_item.AbstractAction):
         return "FF"
 
     def setState(self, r: int, g: int, b: int, led_id: int):
-        if self.device and self.device.enabled and os.path.isfile(self.virpil_executable):
-            rh = self._channel_to_virpil_hex(r)
-            gh = self._channel_to_virpil_hex(g)
-            bh = self._channel_to_virpil_hex(b)
-            syslog.info(f"VIRPIL: setting LED state: r={rh}, g={gh}, b={bh}, led={led_id}")
+        if not self.device or not self.device.enabled:
+            return
 
-            # LED tool expects hex VID/PID and intensity codes (00/40/80/FF), not 0..255 RGB
-            args = [
-                self.virpil_executable,
-                f"{self.device.vendor_id:04x}",
-                f"{self.device.product_id:04x}",
-                str(led_id),
-                rh,
-                gh,
-                bh,
-            ]
-            syslog.info(f"VIRPIL: {' '.join(args)}")
-            # for diagnostics window
-            # subprocess.Popen(args, creationflags=subprocess.CREATE_NEW_CONSOLE)
+        # Prefer direct HID (keeps device open) — fall back to VPC_LED_Control.exe
+        try:
+            import gremlin.virpil_led_hid
 
-            # no window
-            subprocess.Popen(args, creationflags=subprocess.CREATE_NO_WINDOW)
+            if gremlin.virpil_led_hid.VirpilLedHid().set_led(
+                self.device.vendor_id,
+                self.device.product_id,
+                led_id,
+                r,
+                g,
+                b,
+            ):
+                return
+        except Exception as exc:
+            syslog.warning(f"VIRPIL HID: unavailable, using exe fallback: {exc}")
+
+        if not os.path.isfile(self.virpil_executable):
+            syslog.warning("VIRPIL: LED update failed (HID unavailable and executable missing)")
+            return
+
+        rh = self._channel_to_virpil_hex(r)
+        gh = self._channel_to_virpil_hex(g)
+        bh = self._channel_to_virpil_hex(b)
+        syslog.info(f"VIRPIL: setting LED state via exe: r={rh}, g={gh}, b={bh}, led={led_id}")
+
+        # LED tool expects hex VID/PID and intensity codes (00/40/80/FF), not 0..255 RGB
+        args = [
+            self.virpil_executable,
+            f"{self.device.vendor_id:04x}",
+            f"{self.device.product_id:04x}",
+            str(led_id),
+            rh,
+            gh,
+            bh,
+        ]
+        syslog.info(f"VIRPIL: {' '.join(args)}")
+        # for diagnostics window
+        # subprocess.Popen(args, creationflags=subprocess.CREATE_NEW_CONSOLE)
+
+        # no window
+        subprocess.Popen(args, creationflags=subprocess.CREATE_NO_WINDOW)
 
     def _parse_xml(self, node, data=None, extra_data=None):
         assert node.tag == self.tag, f"Expected tag {self.tag} but got {node.tag}"

--- a/action_plugins/virpil_led/__init__.py
+++ b/action_plugins/virpil_led/__init__.py
@@ -33,7 +33,7 @@ import gremlin.event_handler
 import gremlin.config
 from gremlin.input_types import InputType
 import gremlin.input_item
-from enum import IntEnum
+from enum import IntEnum, Enum
 from gremlin.util import safe_read, safe_format, to_guid, delete_widget
 import gremlin.ui.ui_common
 import time
@@ -46,6 +46,7 @@ import gremlin.joystick_handling
 from dinput import DeviceSummary
 import gremlin.ui.ui_common
 from typing import Callable
+from dataclasses import dataclass
 
 
 syslog = logging.getLogger("system")
@@ -53,66 +54,235 @@ syslog = logging.getLogger("system")
 VIRPIL_VENDOR_ID = 0x3344  # HID code for Virpil controllers
 
 
-class VirpilButtonType(IntEnum):
-    # Virpil LED buttons indices
-    ButtonB1 = 6
-    ButtonB2 = 5
-    ButtonB3 = 6
-    ButtonB4 = 7
+@dataclass(frozen=True)
+class VirpilLedOption:
+    """One selectable LED target for a Virpil device family."""
 
-    ButtonB5 = 21
-    ButtonB6 = 18
-    ButtonB7 = 20
-    ButtonB8 = 17
-    ButtonB9 = 19
-    B10 = 16
+    key: str  # stable id for profiles / UI
+    label: str  # human-readable name
+    led_id: int  # ID sent to VPC_LED_Control.exe
 
-    # flight buttons
-    Top = 9
-    Middle = 10
-    FlapsLeft = 11
-    GearLeft = 12
-    GearMiddle = 13
-    GearRight = 14
-    FlapsRight = 15
 
-    # control panel 1
-    Control1B1 = 16
-    Control1B2 = 13
-    Control1B3 = 15
-    Control1B4 = 12
-    Control1B5 = 14
-    Control1B6 = 11
+class VirpilDeviceFamily(Enum):
+    """Device families with distinct LED ID layouts (see virpil/m77_vpc_leds.py)."""
 
-    Control1B7 = 8
-    Control1B8 = 9
-    Control1B9 = 10
-    Control1B10 = 5
-    Control1B11 = 6
-    Control1B12 = 7
+    Stick = "stick"
+    Throttle = "throttle"
+    ControlPanel1 = "control_panel_1"
+    ControlPanel2 = "control_panel_2"
+    Unknown = "unknown"
 
-    # throttle buttons
-    ThrottleB1 = 5
-    ThrottleB2 = 6
-    ThrottleB3 = 7
-    ThrottleB4 = 8
-    ThrottleB5 = 9
-    ThrottleB6 = 10
 
-    # stick buttons
-    StickB1 = 1
+# LED maps for VPC_LED_Control.exe
+#
+# Command numbers are the values in the tool dropdown brackets, extracted from
+# VPC_LED_Control.exe (v2024+/2025):
+#   [001]-[020] On-board #01-#20
+#   [021]-[040] Slave1 #01-#20   (Alpha Prime grip LEDs appear here as Slave1)
+#   [041]-[060] Slave2 #01-#20
+#   [061]-[080] Slave3 #01-#20
+#   [081]-[100] Slave4 #01-#20
+#   [101] All RGB LEDs
+#   [102] All On-board
+#   [103]-[106] All Slave1-4
+#
+# Control Panel #2 On-board map verified from Virpil forum (JasonAlaska).
+# Other panel/throttle families use On-board indices (legacy plugin HID IDs
+# were typically On-board+4 and are wrong for this tool).
+# Alpha Prime sticks: VPC Config shows grip LEDs under Add-boards / Slave1
+# with 9 LEDs — those are Slave1 #01-#09 => commands 21-29.
+VIRPIL_DEVICE_LEDS: dict[VirpilDeviceFamily, list[VirpilLedOption]] = {
+    VirpilDeviceFamily.Stick: [
+        VirpilLedOption("grip_01", "LED 01", 21),
+        VirpilLedOption("grip_02", "LED 02", 22),
+        VirpilLedOption("grip_03", "LED 03", 23),
+        VirpilLedOption("grip_04", "LED 04", 24),
+        VirpilLedOption("grip_05", "LED 05", 25),
+        VirpilLedOption("grip_06", "LED 06", 26),
+        VirpilLedOption("grip_07", "LED 07", 27),
+        VirpilLedOption("grip_08", "LED 08", 28),
+        VirpilLedOption("grip_09", "LED 09", 29),
+    ],
+    VirpilDeviceFamily.Throttle: [
+        VirpilLedOption("b1", "B1", 1),
+        VirpilLedOption("b2", "B2", 2),
+        VirpilLedOption("b3", "B3", 3),
+        VirpilLedOption("b4", "B4", 4),
+        VirpilLedOption("b5", "B5", 5),
+        VirpilLedOption("b6", "B6", 6),
+    ],
+    VirpilDeviceFamily.ControlPanel1: [
+        VirpilLedOption("b1", "B1", 12),
+        VirpilLedOption("b2", "B2", 9),
+        VirpilLedOption("b3", "B3", 11),
+        VirpilLedOption("b4", "B4", 8),
+        VirpilLedOption("b5", "B5", 10),
+        VirpilLedOption("b6", "B6", 7),
+        VirpilLedOption("b7", "B7", 4),
+        VirpilLedOption("b8", "B8", 5),
+        VirpilLedOption("b9", "B9", 6),
+        VirpilLedOption("b10", "B10", 1),
+        VirpilLedOption("b11", "B11", 2),
+        VirpilLedOption("b12", "B12", 3),
+    ],
+    VirpilDeviceFamily.ControlPanel2: [
+        VirpilLedOption("rudder", "Rudder", 5),
+        VirpilLedOption("center", "Center (above gear)", 6),
+        VirpilLedOption("flaps_left", "Flaps left", 7),
+        VirpilLedOption("gear_left", "Gear left", 8),
+        VirpilLedOption("gear_middle", "Gear middle", 9),
+        VirpilLedOption("gear_right", "Gear right", 10),
+        VirpilLedOption("flaps_right", "Flaps right", 11),
+        VirpilLedOption("b1", "B1", 2),
+        VirpilLedOption("b2", "B2", 1),
+        VirpilLedOption("b3", "B3", 4),
+        VirpilLedOption("b4", "B4", 3),
+        VirpilLedOption("b5", "B5", 17),
+        VirpilLedOption("b6", "B6", 14),
+        VirpilLedOption("b7", "B7", 16),
+        VirpilLedOption("b8", "B8", 13),
+        VirpilLedOption("b9", "B9", 15),
+        VirpilLedOption("b10", "B10", 12),
+    ],
+    VirpilDeviceFamily.Unknown: [],
+}
 
-    @staticmethod
-    def from_string(value: str):
-        value = value.casefold()
-        result = next((btn for btn in VirpilButtonType if btn.name.casefold() == value), None)
-        if result is not None:
-            return result
-        return result
+# USB product IDs — verified against this system's DirectInput device list where noted.
+# Prefer name-based classification when the device name is unambiguous (see classify_virpil_device).
+VIRPIL_PRODUCT_FAMILY: dict[int, VirpilDeviceFamily] = {
+    0x0259: VirpilDeviceFamily.ControlPanel1,  # classic CP1
+    0x4259: VirpilDeviceFamily.ControlPanel1,  # CP1 variant (RIGHT VPC Panel #1 on this system)
+    0x025B: VirpilDeviceFamily.ControlPanel2,
+    0x825B: VirpilDeviceFamily.ControlPanel2,
+    0x8193: VirpilDeviceFamily.Throttle,  # CM2
+    0x0194: VirpilDeviceFamily.Throttle,  # CM3 / MongoosT
+    0x8194: VirpilDeviceFamily.Throttle,  # CM3
+    0x40CB: VirpilDeviceFamily.Stick,  # classic Alpha right
+    0x80CB: VirpilDeviceFamily.Stick,  # classic Alpha left
+    0x4391: VirpilDeviceFamily.Stick,  # RIGHT VPC Stick MT-50CM3 (this system)
+    0x8390: VirpilDeviceFamily.Stick,  # LEFT VPC Stick MT-50CM3 (this system)
+}
 
-    @staticmethod
-    def to_string(value: VirpilButtonType):
-        return value.name.casefold()
+
+def classify_virpil_device(device: DeviceSummary | None) -> VirpilDeviceFamily:
+    """Determine which LED layout applies to a connected Virpil device."""
+    if device is None or not getattr(device, "enabled", False):
+        return VirpilDeviceFamily.Unknown
+
+    name = (device.name or "").casefold()
+
+    # Name first — product IDs vary by firmware/revision and are easy to mis-map
+    if "panel #1" in name or "panel 1" in name or "cp1" in name:
+        return VirpilDeviceFamily.ControlPanel1
+    if "panel #2" in name or "panel 2" in name or "cp2" in name:
+        return VirpilDeviceFamily.ControlPanel2
+    # Sticks often include base names like "MT-50CM3" — check stick/alpha before CM3
+    if "stick" in name or "alpha" in name:
+        return VirpilDeviceFamily.Stick
+    if "mongoos" in name or "throttle" in name or "cm3" in name or "cm2" in name:
+        return VirpilDeviceFamily.Throttle
+
+    family = VIRPIL_PRODUCT_FAMILY.get(int(device.product_id or 0))
+    if family is not None:
+        return family
+
+    return VirpilDeviceFamily.Unknown
+
+# Map legacy flat enum names (pre device-aware lists) to LED keys
+_LEGACY_LED_KEY_MAP = {
+    "buttonb1": "b1",
+    "buttonb2": "b2",
+    "buttonb3": "b3",
+    "buttonb4": "b4",
+    "buttonb5": "b5",
+    "buttonb6": "b6",
+    "buttonb7": "b7",
+    "buttonb8": "b8",
+    "buttonb9": "b9",
+    "b10": "b10",
+    "top": "rudder",
+    "middle": "center",
+    "rudder": "rudder",
+    "center": "center",
+    "flapsleft": "flaps_left",
+    "gearleft": "gear_left",
+    "gearmiddle": "gear_middle",
+    "gearright": "gear_right",
+    "flapsright": "flaps_right",
+    "flaps_left": "flaps_left",
+    "gear_left": "gear_left",
+    "gear_middle": "gear_middle",
+    "gear_right": "gear_right",
+    "flaps_right": "flaps_right",
+    "control1b1": "b1",
+    "control1b2": "b2",
+    "control1b3": "b3",
+    "control1b4": "b4",
+    "control1b5": "b5",
+    "control1b6": "b6",
+    "control1b7": "b7",
+    "control1b8": "b8",
+    "control1b9": "b9",
+    "control1b10": "b10",
+    "control1b11": "b11",
+    "control1b12": "b12",
+    "throttleb1": "b1",
+    "throttleb2": "b2",
+    "throttleb3": "b3",
+    "throttleb4": "b4",
+    "throttleb5": "b5",
+    "throttleb6": "b6",
+    "stickb1": "grip_01",
+    "stick_led": "grip_01",
+    "grip_01": "grip_01",
+    "grip_02": "grip_02",
+    "grip_03": "grip_03",
+    "grip_04": "grip_04",
+    "grip_05": "grip_05",
+    "grip_06": "grip_06",
+    "grip_07": "grip_07",
+    "grip_08": "grip_08",
+    "grip_09": "grip_09",
+}
+
+
+def leds_for_device(device: DeviceSummary | None) -> list[VirpilLedOption]:
+    """Return LED options for the selected device family."""
+    return list(VIRPIL_DEVICE_LEDS.get(classify_virpil_device(device), []))
+
+
+def available_leds_for_device(device: DeviceSummary | None, exclude_keys: set[str] | None = None) -> list[VirpilLedOption]:
+    """LED options for a device, optionally skipping keys already added."""
+    exclude = exclude_keys or set()
+    return [led for led in leds_for_device(device) if led.key not in exclude]
+
+
+def normalize_led_key(value: str | None) -> str:
+    if not value:
+        return "b1"
+    key = value.casefold().strip()
+    return _LEGACY_LED_KEY_MAP.get(key, key)
+
+
+def resolve_led_option(device: DeviceSummary | None, led_key: str | None) -> VirpilLedOption | None:
+    """Resolve a stored LED key to the option/id for the current device."""
+    leds = leds_for_device(device)
+    if not leds:
+        return None
+    key = normalize_led_key(led_key)
+    match = next((led for led in leds if led.key == key), None)
+    return match if match is not None else leds[0]
+
+
+def led_display_label(device: DeviceSummary | None, led_key: str | None) -> str:
+    """Human label for an LED key on the current device (B1, Gear left, LED 01, ...)."""
+    option = resolve_led_option(device, led_key)
+    return option.label if option else (led_key or "LED")
+
+
+def led_combo_source(device: DeviceSummary | None) -> list[tuple[str, str]]:
+    """Combo source tuples: (display label, led key)."""
+    return [(led.label, led.key) for led in leds_for_device(device)]
 
 
 class VirpilOutputMode(IntEnum):
@@ -234,17 +404,33 @@ class VirpilButton:
     tag = "virpil-button"
 
     def __init__(
-        self, index: int = -1, device: DeviceSummary = None, mode: VirpilIntensity = None, channel: VirpilButtonChannel = None, led: VirpilButtonType = None
+        self,
+        index: int = -1,
+        device: DeviceSummary = None,
+        mode: VirpilIntensity = None,
+        channel: VirpilButtonChannel = None,
+        led_key: str = None,
+        led_id: int = None,
     ):
         self.id = gremlin.util.get_guid()  # unique ID
         self.device: DeviceSummary = device  # device reference
-        # self.mode: VirpilIntensity = mode
-        # self.channel: VirpilButtonChannel = channel
-        self.led: VirpilButtonType = led
+        self.led_key: str = normalize_led_key(led_key)
+        option = resolve_led_option(device, self.led_key)
+        self.led_id: int = led_id if led_id is not None else (option.led_id if option else 0)
 
         self.rgb: int = 0
 
         self.index: int = index
+
+    def sync_led_to_device(self, device: DeviceSummary | None):
+        """Re-resolve LED id/key for the currently selected Virpil device."""
+        option = resolve_led_option(device, self.led_key)
+        if option is None:
+            self.led_key = "b1"
+            self.led_id = 0
+            return
+        self.led_key = option.key
+        self.led_id = option.led_id
 
     def hexToRGB(self, hex: str):
         hex = hex.lstrip("#")
@@ -323,9 +509,8 @@ class VirpilButton:
 
     def to_xml(self):
         node = ElementTree.Element(self.tag)
-        # node.set("mode", VirpilIntensity.to_string(self.mode))
-        # node.set("channel", VirpilButtonChannel.to_string(self.channel))
-        node.set("led", VirpilButtonType.to_string(self.led))
+        node.set("led", safe_format(self.led_key, str))
+        node.set("led_id", safe_format(self.led_id, int))
         node.set("index", safe_format(self.index, int))
         node.set("guid", safe_format(self.id, str))
         node.set("rgb", safe_format(self.rgb, int))
@@ -333,9 +518,8 @@ class VirpilButton:
 
     def from_xml(self, node):
         assert node.tag == VirpilButton.tag, f"Expected tag {VirpilButton.tag} but got {node.tag}"
-        self.led = VirpilButtonType.from_string(safe_read(node, "led", str, "buttonb1"))
-        # self.mode = VirpilIntensity.from_string(safe_read(node, "mode", str, "off"))
-        # self.channel = VirpilButtonChannel.from_string(safe_read(node, "channel", str, "red"))
+        self.led_key = normalize_led_key(safe_read(node, "led", str, "b1"))
+        self.led_id = safe_read(node, "led_id", int, 0)
         self.index = safe_read(node, "index", int, -1)
         self.id = safe_read(node, "guid", str, gremlin.util.get_guid())
         self.rgb = safe_read(node, "rgb", int, 0)
@@ -358,7 +542,8 @@ class VirpilActionModel(gremlin.input_item.AbstractCallbackModel):
         self.action_data = action_data
 
     def add(self, button: VirpilButton, index: int = -1):
-        super().add(button, index=index)
+        # super().add allocates the real slot when index == -1; keep button.index in sync
+        index = super().add(button, index=index)
         button.index = index
         syslog.info(f"added button, new count: {len(self)}")
 
@@ -385,7 +570,7 @@ class VirpilActionModel(gremlin.input_item.AbstractCallbackModel):
 
 
 class VirpilButtonWidget(QtWidgets.QWidget):
-    """displays a virpil button selector"""
+    """displays a configured Virpil LED row (label + color)"""
 
     def __init__(self, action_data: VirpilAction, button_data: VirpilButton, index: int = -1, delete_callback: Callable = None, parent=None):
         super().__init__(parent)
@@ -397,18 +582,14 @@ class VirpilButtonWidget(QtWidgets.QWidget):
         self.index: int = index  # index in the list
         self.selected: bool = False  # true if selected
 
-        main_widgets = ["LED:"]
+        self.button_data.sync_led_to_device(self.action_data.device)
+        label_text = led_display_label(self.action_data.device, self.button_data.led_key)
+        self.led_label_widget = QtWidgets.QLabel(label_text)
+        self.led_label_widget.setMinimumWidth(120)
 
-        # button type selector
-        items = [(led.name, led) for led in VirpilButtonType]
-        self.button_selector = gremlin.ui.ui_common.QDataComboBox(
-            source=items, tooltip="Virpil Button Selector", value=self.button_data.led, callback=self._handle_led_changed
-        )
-        self.button_selector.setWidthToContent()
-        main_widgets.append(self.button_selector)
+        main_widgets = ["LED:", self.led_label_widget]
 
         # color
-
         self.current_color_widget = QtWidgets.QLabel("     ")
         self.current_color_widget.setFixedWidth(50)
         self._update_color()
@@ -423,6 +604,11 @@ class VirpilButtonWidget(QtWidgets.QWidget):
 
         widget = gremlin.ui.ui_common.getHContainer(main_widgets, widget_only=True, no_stretch=True)
         self.main_layout.addWidget(widget)
+
+    def refresh_led_options(self):
+        """Refresh the displayed LED label after the parent Virpil device changes."""
+        self.button_data.sync_led_to_device(self.action_data.device)
+        self.led_label_widget.setText(led_display_label(self.action_data.device, self.button_data.led_key))
 
     def _handle_get_color(self):
         color = QColor.fromRgb(self.button_data.rgb)
@@ -439,18 +625,91 @@ class VirpilButtonWidget(QtWidgets.QWidget):
 
     def _handle_delete(self):
         """handles the delete button click"""
-        # Implement the delete functionality here
         if self.delete_callback:
             self.delete_callback(self)
 
-    def _handle_led_changed(self, new_led: VirpilButtonType):
-        self.button_data.led = new_led
 
-    def _handle_mode_changed(self, new_mode: VirpilIntensity):
-        self.button_data.mode = new_mode
+class VirpilLedPickerDialog(QtWidgets.QDialog):
+    """Dialog to choose one or more device LEDs to add."""
 
-    def _handle_channel_changed(self, new_channel: VirpilButtonChannel):
-        self.button_data.channel = new_channel
+    def __init__(self, device: DeviceSummary, existing_keys: set[str] | None = None, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Add Virpil LED")
+        self.setMinimumWidth(360)
+        self.setMinimumHeight(420)
+
+        self._device = device
+        self._existing_keys = existing_keys or set()
+        self.selected_keys: list[str] = []
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel("Select LED(s) to add:"))
+
+        self.list_widget = QtWidgets.QListWidget()
+        self.list_widget.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        available = available_leds_for_device(device, self._existing_keys)
+        for led in available:
+            item = QtWidgets.QListWidgetItem(led.label)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, led.key)
+            self.list_widget.addItem(item)
+        self.list_widget.itemDoubleClicked.connect(self._add_selected)
+        layout.addWidget(self.list_widget)
+
+        if not available:
+            layout.addWidget(gremlin.ui.ui_common.QWarningWidget("All LEDs for this device are already added."))
+
+        self.add_selected_widget = gremlin.ui.ui_common.Buttons.getOkWidget(
+            label="Add Selected", callback=self._add_selected
+        )
+        self.add_all_widget = gremlin.ui.ui_common.QDataPushButton("Add All", callback=self._add_all)
+        self.cancel_widget = gremlin.ui.ui_common.Buttons.getCancelWidget(callback=self.reject)
+
+        self.add_selected_widget.setEnabled(bool(available))
+        self.add_all_widget.setEnabled(bool(available))
+
+        buttons = gremlin.ui.ui_common.getHContainer(
+            [self.add_selected_widget, self.add_all_widget, self.cancel_widget],
+            widget_only=True,
+            left_stretch=True,
+        )
+        layout.addWidget(buttons)
+
+        if available:
+            self.list_widget.setCurrentRow(0)
+
+    def _keys_from_selection(self) -> list[str]:
+        keys = []
+        for item in self.list_widget.selectedItems():
+            key = item.data(QtCore.Qt.ItemDataRole.UserRole)
+            if key:
+                keys.append(key)
+        return keys
+
+    def _add_selected(self):
+        keys = self._keys_from_selection()
+        if not keys:
+            # If nothing highlighted, add the current row
+            item = self.list_widget.currentItem()
+            if item is not None:
+                key = item.data(QtCore.Qt.ItemDataRole.UserRole)
+                if key:
+                    keys = [key]
+        if not keys:
+            return
+        self.selected_keys = keys
+        self.accept()
+
+    def _add_all(self):
+        keys = []
+        for row in range(self.list_widget.count()):
+            item = self.list_widget.item(row)
+            key = item.data(QtCore.Qt.ItemDataRole.UserRole)
+            if key:
+                keys.append(key)
+        if not keys:
+            return
+        self.selected_keys = keys
+        self.accept()
 
 
 class VirpilExecutableDialog(QtWidgets.QDialog):
@@ -577,11 +836,17 @@ class VirpilActionWidget(gremlin.input_item.AbstractActionWidget):
         self.main_layout.addWidget(self.output_mode_widget)
         self.main_layout.addWidget(self.device_selector)
 
+        self.no_device_warning_widget = gremlin.ui.ui_common.QWarningWidget(
+            "Select a Virpil device first before adding LEDs."
+        )
+        self.main_layout.addWidget(self.no_device_warning_widget)
+
         self.main_layout.addWidget(self.view_widget)
 
         # button bar
         widgets = [self.add_widget, self.test_widget]
         container = gremlin.ui.ui_common.getHContainer(widgets, widget_only=True)
+        self.button_bar_widget = container
         self.main_layout.addWidget(container)
 
         # delay widget
@@ -594,6 +859,11 @@ class VirpilActionWidget(gremlin.input_item.AbstractActionWidget):
 
         self._update()
 
+    def _has_valid_device(self) -> bool:
+        """True when a real Virpil device (not 'No Device') is selected."""
+        device = self.action_data.device
+        return device is not None and bool(getattr(device, "enabled", False))
+
     def _handle_configure(self):
         dialog = VirpilExecutableDialog(self.action_data, parent=self)
         dialog.exec_()
@@ -603,6 +873,8 @@ class VirpilActionWidget(gremlin.input_item.AbstractActionWidget):
         for widget in self._widget_map.values():
             delete_widget(widget)
         self._widget_map.clear()
+        if not self._has_valid_device():
+            return
         for index, button in enumerate(self.action_data.model):
             widget = VirpilButtonWidget(self.action_data, button, delete_callback=self._handle_delete, index = index)
             item = QtWidgets.QListWidgetItem()
@@ -613,14 +885,22 @@ class VirpilActionWidget(gremlin.input_item.AbstractActionWidget):
             self._widget_map[index] = widget
 
     def _update(self):
-        pulse_visible = self.action_data.output_mode == VirpilOutputMode.Pulse
+        has_device = self._has_valid_device()
+        pulse_visible = has_device and self.action_data.output_mode == VirpilOutputMode.Pulse
         self.pulse_container_widget.setVisible(pulse_visible)
+        self.no_device_warning_widget.setVisible(not has_device)
+        self.view_widget.setVisible(has_device)
+        self.button_bar_widget.setVisible(has_device)
+        self.add_widget.setEnabled(has_device)
+        self.test_widget.setEnabled(has_device)
 
     def _handle_test(self):
+        if not self._has_valid_device():
+            return
         if self.action_data.device and self.action_data.device.enabled:
             for button in self.action_data.model:
                 r, g, b = button.getRGB()
-                self.action_data.setState(r, g, b, button.led)
+                self.action_data.setState(r, g, b, button.led_id)
 
 
     def _handle_delay_changed(self, value: int):
@@ -653,29 +933,64 @@ class VirpilActionWidget(gremlin.input_item.AbstractActionWidget):
             self._populate_ui()
 
     def _handle_add(self):
+        if not self._has_valid_device():
+            return
+        existing = {button.led_key for button in self.action_data.model}
+        dialog = VirpilLedPickerDialog(self.action_data.device, existing_keys=existing, parent=self)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return
+        for led_key in dialog.selected_keys:
+            self._add_led(led_key, refresh=False)
+        self._update_view_widget()
+
+    def _add_led(self, led_key: str, refresh: bool = True):
+        option = resolve_led_option(self.action_data.device, led_key)
+        if option is None:
+            return
+        # Skip duplicates
+        if any(button.led_key == option.key for button in self.action_data.model):
+            return
         button = VirpilButton(
             index=len(self.action_data.model),
             device=self.action_data.device,
             mode=VirpilIntensity.Max,
             channel=VirpilButtonChannel.Blue,
-            led=VirpilButtonType.ButtonB1,
+            led_key=option.key,
+            led_id=option.led_id,
         )
         self.action_data.model.add(button)
-        self._update_view_widget()
-
-    def _handle_delete(self, widget: VirpilButtonWidget)        :
-        index = widget.index
-        if index != -1:
-            self.action_data.model.removeAt(index)
+        if refresh:
             self._update_view_widget()
 
-    def _handle_mode_changed(self, widget: VirpilButtonWidget, checked : bool):
+    def _handle_delete(self, widget: VirpilButtonWidget):
+        # Remove by object — model indices can be sparse after prior deletes,
+        # so enumerate() widget positions are not reliable removeAt() keys.
+        button = widget.button_data
+        if button is not None:
+            self.action_data.model.remove(button)
+            self._reindex_buttons()
+            self._update_view_widget()
+
+    def _reindex_buttons(self):
+        """Compact model slots to 0..n-1 so UI and XML indices stay consistent."""
+        buttons = list(self.action_data.model)
+        self.action_data.model.clear(emit=False)
+        for i, button in enumerate(buttons):
+            button.index = i
+            self.action_data.model.add(button, index=i)
+
+    def _handle_mode_changed(self, widget, checked: bool):
         if checked:
-            mode: VirpilIntensity = widget.data
-            self.action_data.mode = mode
+            self.action_data.output_mode = widget.data
+            self._update()
 
     def _handle_device_changed(self, device : dinput.DeviceSummary):
         self.action_data.device = device
+        for button in self.action_data.model:
+            button.sync_led_to_device(device)
+        # Rebuild LED rows so each dropdown shows only this device's LEDs
+        self._update_view_widget()
+        self._update()
 
     @QtCore.Slot(bool)
     def _execute_on_press_changed(self, checked: bool):
@@ -734,12 +1049,12 @@ class VirpilActionFunctor(gremlin.base_profile.AbstractFunctor):
                         # turn off
                         r, g, b = 0, 0, 0
 
-                    self.action_data.setState(r, g, b, button.led)
+                    self.action_data.setState(r, g, b, button.led_id)
             case VirpilOutputMode.Pulse:
                 if trigger:
                     for button in self.action_data.model:
                         r, g, b = button.getRGB()
-                        self.action_data.setState(r, g, b, button.led)
+                        self.action_data.setState(r, g, b, button.led_id)
                     self._pulse_timer = threading.Timer(self.action_data.pulse_duration / 1000.0, self._turn_off_leds)
                     self._pulse_timer.start()
 
@@ -750,17 +1065,17 @@ class VirpilActionFunctor(gremlin.base_profile.AbstractFunctor):
                     if self._toggle_state:
                         for button in self.action_data.model:
                             r, g, b = button.getRGB()
-                            self.action_data.setState(r, g, b, button.led)
+                            self.action_data.setState(r, g, b, button.led_id)
                     else:
                         for button in self.action_data.model:
-                            self.action_data.setState(0, 0, 0, button.led)
+                            self.action_data.setState(0, 0, 0, button.led_id)
 
         return True
 
     def _turn_off_leds(self):
         if self._valid:
             for button in self.action_data.model:
-                self.action_data.setState(0, 0, 0, button.led)
+                self.action_data.setState(0, 0, 0, button.led_id)
 
 
 class VirpilAction(gremlin.input_item.AbstractAction):
@@ -825,18 +1140,41 @@ class VirpilAction(gremlin.input_item.AbstractAction):
     def requires_virtual_button(self):
         return self.get_input_type() in [InputType.JoystickAxis, InputType.JoystickHat]
 
-    def setState(self, r: int, g: int, b: int, led: VirpilButtonType):
-        if self.device and self.device.enabled and os.path.isfile(self.virpil_executable):
-            syslog.info(f"VIRPIL: setting LED state: r={r}, g={g}, b={b}, led={led.value}")
+    @staticmethod
+    def _channel_to_virpil_hex(value: int) -> str:
+        """Map a 0..255 color channel to Virpil LED tool intensity codes."""
+        # VPC_LED_Control accepts only: 00 (off), 40 (low), 80 (mid), FF (max)
+        if value <= 0:
+            return "00"
+        if value <= 76:
+            return "40"
+        if value <= 153:
+            return "80"
+        return "FF"
 
-            # LED tool expects the product and vendor IDs to be in hex values, 4 digits
-            command = f"{self.virpil_executable} {self.device.vendor_id:04x} {self.device.product_id:04x} {led.value} {r} {g} {b}"
-            syslog.info(f"VIRPIL: {command}")
+    def setState(self, r: int, g: int, b: int, led_id: int):
+        if self.device and self.device.enabled and os.path.isfile(self.virpil_executable):
+            rh = self._channel_to_virpil_hex(r)
+            gh = self._channel_to_virpil_hex(g)
+            bh = self._channel_to_virpil_hex(b)
+            syslog.info(f"VIRPIL: setting LED state: r={rh}, g={gh}, b={bh}, led={led_id}")
+
+            # LED tool expects hex VID/PID and intensity codes (00/40/80/FF), not 0..255 RGB
+            args = [
+                self.virpil_executable,
+                f"{self.device.vendor_id:04x}",
+                f"{self.device.product_id:04x}",
+                str(led_id),
+                rh,
+                gh,
+                bh,
+            ]
+            syslog.info(f"VIRPIL: {' '.join(args)}")
             # for diagnostics window
-            # subprocess.Popen(command, creationflags=subprocess.CREATE_NEW_CONSOLE)
+            # subprocess.Popen(args, creationflags=subprocess.CREATE_NEW_CONSOLE)
 
             # no window
-            subprocess.Popen(command, creationflags=subprocess.CREATE_NO_WINDOW)
+            subprocess.Popen(args, creationflags=subprocess.CREATE_NO_WINDOW)
 
     def _parse_xml(self, node, data=None, extra_data=None):
         assert node.tag == self.tag, f"Expected tag {self.tag} but got {node.tag}"
@@ -849,6 +1187,8 @@ class VirpilAction(gremlin.input_item.AbstractAction):
         model_node = node.xpath(f"./{VirpilActionModel.tag}")
         if model_node is not None:
             self.model.from_xml(model_node[0])
+        for button in self.model:
+            button.sync_led_to_device(self.device)
         self.output_mode = VirpilOutputMode.from_string(safe_read(node, "output_mode", str, "hold"))
 
         self.exec_on_press = safe_read(node, "exec_on_press", bool, True)

--- a/gremlin/virpil_led_hid.py
+++ b/gremlin/virpil_led_hid.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# Direct HID feature-report path for Virpil device LEDs.
+# Protocol based on community documentation (charliefoxtwo / Virpil Communicator),
+# firmware era ~20210102+. Sending raw HID data is at-your-own-risk.
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from gremlin.singleton_decorator import SingletonDecorator
+
+# Ensure hidapi.dll is loaded before importing hid (same as gremlin.hid)
+import gremlin.hid  # noqa: F401
+import hid
+
+syslog = logging.getLogger("system")
+
+VIRPIL_VENDOR_ID = 0x3344
+
+# Board type bytes for feature reports
+BOARD_DEFAULT = 0x64
+BOARD_ADD = 0x65
+BOARD_ONBOARD = 0x66
+BOARD_SLAVE = 0x67
+BOARD_EXTRA = 0x68
+
+REPORT_ID = 0x02
+REPORT_SIZE = 38
+REPORT_TERMINATOR = 0xF0
+
+
+def _channel_to_2bit(value: int) -> int:
+    """Map 0..255 channel to Virpil 2-bit intensity (00/01/10/11)."""
+    if value <= 0:
+        return 0
+    if value <= 76:
+        return 1  # ~25% (tool 40)
+    if value <= 153:
+        return 2  # ~50% (tool 80)
+    return 3  # 100% (tool FF)
+
+
+def pack_color_byte(r: int, g: int, b: int) -> int:
+    """Pack RGB into Virpil color byte: 10 bb gg rr."""
+    rr = _channel_to_2bit(r)
+    gg = _channel_to_2bit(g)
+    bb = _channel_to_2bit(b)
+    return 0x80 | (bb << 4) | (gg << 2) | rr
+
+
+def tool_led_id_to_board_and_index(tool_led_id: int) -> tuple[int, int] | None:
+    """
+    Convert VPC_LED_Control dropdown command IDs to HID board + local LED index.
+
+    Tool IDs:
+      1-20  = On-board #01-#20
+      21-40 = Slave1 #01-#20
+    """
+    if 1 <= tool_led_id <= 20:
+        return BOARD_ONBOARD, tool_led_id
+    if 21 <= tool_led_id <= 40:
+        return BOARD_SLAVE, tool_led_id - 20
+    return None
+
+
+def board_command(board: int, local_led: int) -> int | None:
+    """HID command byte for a board-local LED index (1-based)."""
+    if local_led < 1:
+        return None
+    if board == BOARD_ADD:
+        if local_led > 4:
+            return None
+        return local_led  # 0x01-0x04
+    if board == BOARD_ONBOARD:
+        if local_led > 20:
+            return None
+        return local_led + 0x04  # 0x05-0x18
+    if board == BOARD_SLAVE:
+        if local_led > 20:
+            return None
+        return local_led + 0x18  # 0x19-0x2C
+    if board == BOARD_EXTRA:
+        if local_led > 10:
+            return None
+        return local_led + 0x2C  # 0x2D-0x36
+    if board == BOARD_DEFAULT:
+        return 0x00
+    return None
+
+
+def build_feature_report(board: int, local_led: int, r: int, g: int, b: int) -> bytes | None:
+    """Build the 38-byte Virpil LED feature report."""
+    command = board_command(board, local_led)
+    if command is None:
+        return None
+    color_index = local_led + 4
+    if color_index < 0 or color_index >= REPORT_SIZE - 1:
+        return None
+
+    data = [0] * REPORT_SIZE
+    data[0] = REPORT_ID
+    data[1] = board & 0xFF
+    data[2] = command & 0xFF
+    data[color_index] = pack_color_byte(r, g, b) & 0xFF
+    data[REPORT_SIZE - 1] = REPORT_TERMINATOR
+    return bytes(data)
+
+
+@SingletonDecorator
+class VirpilLedHid:
+    """Keeps Virpil HID devices open and sends LED feature reports."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        # key: (vid, pid) -> hid.Device
+        self._devices: dict[tuple[int, int], hid.Device] = {}
+        # paths that failed recently — avoid hammering logs
+        self._fail_logged: set[tuple[int, int]] = set()
+
+    def close_all(self):
+        """Close all open HID handles (e.g. on profile stop)."""
+        with self._lock:
+            for key, device in list(self._devices.items()):
+                try:
+                    device.close()
+                except Exception:
+                    pass
+                self._devices.pop(key, None)
+            self._fail_logged.clear()
+
+    def close_device(self, vid: int, pid: int):
+        with self._lock:
+            key = (int(vid), int(pid))
+            device = self._devices.pop(key, None)
+            if device is not None:
+                try:
+                    device.close()
+                except Exception:
+                    pass
+
+    def _candidate_paths(self, vid: int, pid: int) -> list[bytes]:
+        """Return HID device paths for vid/pid (vendor interface preferred)."""
+        entries: list[tuple[int, bytes]] = []
+        try:
+            for info in hid.enumerate(vid, pid):
+                path = info.get("path")
+                if not path:
+                    continue
+                # Prefer vendor usage page (0xFF00) used for Virpil LED feature reports
+                usage_page = int(info.get("usage_page") or 0)
+                priority = 0 if usage_page == 0xFF00 else 1
+                entries.append((priority, path))
+        except Exception as exc:
+            syslog.warning(f"VIRPIL HID: enumerate failed for {vid:04X}:{pid:04X}: {exc}")
+
+        entries.sort(key=lambda item: item[0])
+        paths: list[bytes] = []
+        for _, path in entries:
+            if path not in paths:
+                paths.append(path)
+        return paths
+
+    def _open_device(self, vid: int, pid: int) -> hid.Device | None:
+        """Open the first HID interface that can be opened for vid/pid."""
+        vid = int(vid)
+        pid = int(pid)
+        paths = self._candidate_paths(vid, pid)
+        last_error = None
+
+        if not paths:
+            try:
+                device = hid.Device(vid, pid)
+                device.nonblocking = 1
+                return device
+            except Exception as exc:
+                syslog.warning(f"VIRPIL HID: open failed for {vid:04X}:{pid:04X}: {exc}")
+                return None
+
+        for path in paths:
+            try:
+                device = hid.Device(path=path)
+                device.nonblocking = 1
+                return device
+            except Exception as exc:
+                last_error = exc
+                continue
+
+        if last_error is not None:
+            syslog.warning(f"VIRPIL HID: open failed for {vid:04X}:{pid:04X}: {last_error}")
+        return None
+
+    def _try_send_on_paths(self, vid: int, pid: int, report: bytes) -> bool:
+        """Try feature report on each HID interface until one accepts it."""
+        vid = int(vid)
+        pid = int(pid)
+        key = (vid, pid)
+        paths = self._candidate_paths(vid, pid)
+        if not paths:
+            paths = [None]  # vid/pid open
+
+        last_error = None
+        for path in paths:
+            device = None
+            try:
+                if path is None:
+                    device = hid.Device(vid, pid)
+                else:
+                    device = hid.Device(path=path)
+                device.nonblocking = 1
+                device.send_feature_report(report)
+                self._devices[key] = device
+                self._fail_logged.discard(key)
+                syslog.info(f"VIRPIL HID: opened device {vid:04X}:{pid:04X}")
+                return True
+            except Exception as exc:
+                last_error = exc
+                if device is not None:
+                    try:
+                        device.close()
+                    except Exception:
+                        pass
+                continue
+
+        if last_error is not None and key not in self._fail_logged:
+            syslog.warning(f"VIRPIL HID: send_feature_report failed for {vid:04X}:{pid:04X}: {last_error}")
+            self._fail_logged.add(key)
+        return False
+
+    def _get_device(self, vid: int, pid: int) -> hid.Device | None:
+        key = (int(vid), int(pid))
+        device = self._devices.get(key)
+        if device is not None:
+            return device
+        device = self._open_device(vid, pid)
+        if device is not None:
+            self._devices[key] = device
+            self._fail_logged.discard(key)
+            syslog.info(f"VIRPIL HID: opened device {vid:04X}:{pid:04X}")
+        return device
+
+    def set_led(self, vid: int, pid: int, tool_led_id: int, r: int, g: int, b: int) -> bool:
+        """
+        Set one LED via HID feature report.
+
+        :param tool_led_id: VPC_LED_Control dropdown command number (1-40 typical)
+        :returns: True if the feature report was sent successfully
+        """
+        mapping = tool_led_id_to_board_and_index(int(tool_led_id))
+        if mapping is None:
+            return False
+        board, local_led = mapping
+        report = build_feature_report(board, local_led, int(r), int(g), int(b))
+        if report is None:
+            return False
+
+        key = (int(vid), int(pid))
+        with self._lock:
+            device = self._devices.get(key)
+            if device is not None:
+                try:
+                    device.send_feature_report(report)
+                    return True
+                except Exception as exc:
+                    try:
+                        device.close()
+                    except Exception:
+                        pass
+                    self._devices.pop(key, None)
+                    if key not in self._fail_logged:
+                        syslog.warning(
+                            f"VIRPIL HID: send failed for {vid:04X}:{pid:04X} led={tool_led_id}: {exc}; retrying interfaces"
+                        )
+
+            return self._try_send_on_paths(vid, pid, report)


### PR DESCRIPTION
## Summary
- Add `gremlin/virpil_led_hid.py` to keep Virpil HID handles open and send the documented 38-byte LED feature reports (on-board / slave board mapping from VPC tool command IDs).
- Prefer HID in the Virpil LED action `setState`; automatically fall back to `VPC_LED_Control.exe` if HID open/send fails.
- Close HID handles on profile stop.
- Includes prior Virpil LED fixes from #465 (device-aware LED maps, color intensity codes, delete fix) since this branch builds on that work.

## Test plan
- [ ] Select RIGHT VPC Panel #1, add LEDs, hit Play — LEDs update near-instantly (no multi-second delay)
- [ ] Press a mapped button controlling several LEDs — all update without staggered exe spawn lag
- [ ] Confirm stick grip LEDs (Slave1) still light correctly
- [ ] If HID is blocked (e.g. HidHide), confirm exe fallback still works
- [ ] Stop profile and confirm no leftover HID issues on restart
