### PR TITLE
Fix mouse-wheel Timer.cancel() crash loop on Python 3.14

### DIFF
--- a/gremlin/windows_event_hook.py
+++ b/gremlin/windows_event_hook.py
@@ -395,8 +395,14 @@ def process_mouse_event(n_code, w_param, l_param):
                     _mouse_wheel_state[button_id] = True  # mark pressed
 
                 if _mouse_wheel_timer[button_id]:
-                    # cancel current timer
-                    _mouse_wheel_timer[button_id].cancel()
+                    # cancel current timer. Guarded: on Python 3.14 Timer.cancel()
+                    # can raise "cannot notify on un-acquired lock" when called
+                    # from the ctypes mouse-hook callback, which otherwise loops
+                    # forever and stalls event processing (vJoy output included).
+                    try:
+                        _mouse_wheel_timer[button_id].cancel()
+                    except RuntimeError:
+                        pass
 
                 # new timer
 
@@ -438,8 +444,11 @@ def _queue_wheel_release(button_id):
             syslog.info(f"wheel release {button_id}")
         _mouse_wheel_state[button_id] = False
         if _mouse_wheel_timer[button_id]:
-            # cancel the timer
-            _mouse_wheel_timer[button_id].cancel()
+            # cancel the timer (guarded against Python 3.14 lock RuntimeError)
+            try:
+                _mouse_wheel_timer[button_id].cancel()
+            except RuntimeError:
+                pass
 
         evt = MouseEvent(button_id, False, False)
         for cb in g_mouse_callbacks:
@@ -689,7 +698,10 @@ class MouseHook:
         global _mouse_wheel_timer
         for id in _mouse_wheel_timer:
             if _mouse_wheel_timer[id]:
-                _mouse_wheel_timer[id].cancel()
+                try:
+                    _mouse_wheel_timer[id].cancel()
+                except RuntimeError:
+                    pass
                 _mouse_wheel_timer[id] = None
 
     def _listen(self):


### PR DESCRIPTION
On Python 3.14, using the mouse wheel while a profile is running triggers an
endless exception loop that stalls event processing — vJoy output stops and
the joysticks become unresponsive until GremlinEx is restarted.

## Cause

`windows_event_hook.py` installs a global low-level mouse hook (WH_MOUSE_LL).
Its wheel handling uses a `threading.Timer` and calls `.cancel()` on it from
within the ctypes hook callback. On Python 3.14 `Timer.cancel()` →
`Event.set()` → `Condition.notify_all()` raises:

    RuntimeError: cannot notify on un-acquired lock

Because the hook is global and runs on every wheel event, the exception
repeats on every scroll and floods the event pipeline. In practice this
manifests as vJoy output silently dying "at random" (i.e. whenever the wheel
is used), which is very hard to diagnose since it looks like a vJoy problem.

## Fix

Guard the three `Timer.cancel()` calls in `windows_event_hook.py` with
`try/except RuntimeError`. A timer that can't be cancelled simply fires its
(harmless) wheel-release callback; the important thing is that the hook no
longer crashes and event processing keeps running.

## Testing

On Python 3.14, before the fix: scrolling the wheel while a profile runs
fills the log with `cannot notify on un-acquired lock` and vJoy output drops.
After the fix: heavy wheel scrolling produces no errors and vJoy stays
responsive.