### PR TITLE
Fix child modes not inheriting parent input mappings at runtime

### DIFF
--- a/gremlin/base_profile.py
+++ b/gremlin/base_profile.py
@@ -3473,6 +3473,26 @@ class Profile:
 
         return modes  # unduplicated
 
+    def get_parent_mode(self, mode: str) -> str:
+        """gets the name of the parent (inherited) mode for the given mode.
+
+        Returns None if the mode has no parent (root mode) or is unknown.
+        Used to resolve input item inheritance at event-match time.
+        """
+        if not mode:
+            return None
+        try:
+            mode_node = self._profile_graph.getModeNode(mode)
+        except Exception:
+            return None
+        if mode_node is None:
+            return None
+        parent = mode_node.inherit
+        # guard against a mode inheriting from itself
+        if parent == mode:
+            return None
+        return parent
+
     def get_xml_modes(self, node, casefold=False) -> list[str]:
         """reads profile modes from an XML mode"""
         root = node.getroottree().getroot()

--- a/gremlin/event_handler.py
+++ b/gremlin/event_handler.py
@@ -2505,17 +2505,28 @@ class EventHandler(QtCore.QObject):
             syslog.info(f"Match input: looking for device [{device_name}] input_type: [{input_type.name}/{input_type}] magic: [{magic}]")
 
         if device_guid in self.input_item_map:
-            if mode in self.input_item_map[device_guid]:
-                if input_type in self.input_item_map[device_guid][mode]:
-                    if magic in self.input_item_map[device_guid][mode][input_type]:
+            # walk the mode inheritance chain: a child mode inherits its
+            # parent's input items unless it defines its own. input_item_map is
+            # only populated for the mode where an input is declared, so we must
+            # fall back to parent modes here (mirrors build_event_lookup, which
+            # only propagates inheritance into the callbacks maps, not this one).
+            lookup_mode = mode
+            profile = gremlin.shared_state.current_profile
+            visited = set()
+            while lookup_mode and lookup_mode not in visited:
+                visited.add(lookup_mode)
+                mode_map = self.input_item_map[device_guid].get(lookup_mode)
+                if mode_map and input_type in mode_map:
+                    if magic in mode_map[input_type]:
                         if verbose:
-                            syslog.info(f"Match Input: input item : magic: {magic}")
-                        return self.input_item_map[device_guid][mode][input_type][magic]
-                    else:
-                        if verbose:
-                            syslog.info("available magic values for this input are: ")
-                            for magic in self.input_item_map[device_guid][mode][input_type]:
-                                syslog.info(f"\t{magic}")
+                            syslog.info(f"Match Input: input item : magic: {magic} (mode: {lookup_mode})")
+                        return mode_map[input_type][magic]
+                    elif verbose:
+                        syslog.info("available magic values for this input are: ")
+                        for m in mode_map[input_type]:
+                            syslog.info(f"\t{m}")
+                # ascend to the parent mode, if any
+                lookup_mode = profile.get_parent_mode(lookup_mode) if profile is not None else None
 
         # check latched inputs (these are not real inputs but registered)
         if device_guid in self.latched_functors:


### PR DESCRIPTION
### Problem
After switching into a mode that inherits from another (e.g. a child mode of Default), all buttons inherited from the parent stopped responding. The log showed every inherited input as `no match` / `input disabled`, while inputs declared directly in the active mode worked. Axes bound in the parent were unaffected, which masked the root cause.

### Cause
`_matching_input_item()` searches `input_item_map[device_guid][mode]` with no parent-mode fallback. `input_item_map` is only populated for the mode where an input is declared. `build_event_lookup()` propagates inheritance, but only into the `callbacks` maps — not `input_item_map` — so lookups for inherited inputs in child modes fail.

### Fix
Walk the mode inheritance chain in `_matching_input_item()`, ascending to parent modes until a match is found or the root is reached. A `visited` set guards against inheritance cycles. Adds `Profile.get_parent_mode()`.

This is a minimal, lookup-side fix. An alternative would be to propagate inheritance into `input_item_map` at build time (alongside the callbacks maps in `build_event_lookup`); happy to refactor that way if preferred.

### Testing
Star Citizen profile with Default + several child modes (inherit="Default"). Before: switching into a child mode killed all inherited buttons. After: inherited buttons respond correctly in every child mode.