### PR TITLE
Fix typo: self.fondition -> self.addCondition in condition node init

### DIFF
--- a/gremlin/execution_graph.py
+++ b/gremlin/execution_graph.py
@@ -230,7 +230,7 @@ class BaseExecutionConditionNode(ExecutionGraphNode):
         self.rule = ActivationRule.All  # rule set that applies to the condition node
         self.container = None  # owning container for the condition
         if condition:
-            self.fondition(condition)
+            self.addCondition(condition)
         # self.condition :  gremlin.input_item.BaseActivationCondition = condition # holds the condition
 
     def addCondition(self, condition):


### PR DESCRIPTION
BaseExecutionConditionNode.__init__ called self.fondition(condition), which does not exist, raising AttributeError whenever a condition node was built with a condition. The method is addCondition().