### PR TITLE
Initialize ModeDeviceTabWidget._filter to avoid AttributeError

### DIFF
--- a/gremlin/ui/mode_device.py
+++ b/gremlin/ui/mode_device.py
@@ -317,6 +317,7 @@ class ModeDeviceTabWidget(gremlin.input_item.BaseDeviceTabWidget):
 
         self.current_mode = mode
         self.widget_storage = {}
+        self._filter = ""  # active search filter string (empty = no filtering)
 
         el = gremlin.event_handler.EventListener()
         el.profile_loaded.connect(self._handle_new_profile)


### PR DESCRIPTION
_filter_data() reads self._filter, but it was never initialized, raising AttributeError ('ModeDeviceTabWidget' object has no attribute '_filter') when the filter ran (e.g. on profile stop). Initialize it to an empty string in __init__, so no filtering is applied until a search term is set.