### PR TITLE
Fix container deletion silently failing on copyFrom of Qt-bound items

### DIFF
--- a/gremlin/util.py
+++ b/gremlin/util.py
@@ -2729,7 +2729,14 @@ class TriggerDict(collections.UserDict):
         if isinstance(source, dict):
             new_dict = TriggerDict()
             for key, value in source.items():
-                new_dict[key] = copy.deepcopy(value) if deep else copy.copy(value)
+                # Reference the value by default rather than copy.copy()-ing it.
+                # These maps hold model items that own Qt widgets/signals; copying
+                # an item whose widget has already been torn down raises
+                # "RuntimeError: Signal source has been deleted" (e.g. during
+                # container deletion). Index maps must preserve item identity, so
+                # a shallow reference is what we actually want. deep=True still
+                # deep-copies for the rare caller that needs an independent copy.
+                new_dict[key] = copy.deepcopy(value) if deep else value
             return new_dict
 
         if deep:


### PR DESCRIPTION
### Problem
Deleting a container (trash icon -> confirm Yes) does nothing: the dialog
closes but the container stays. No visible error.

### Cause
`TriggerDict.copyFrom` deep/shallow-copies every value. `AbstractModel`'s
index and item maps hold model items that own Qt widgets/signals. When a
container is deleted its widget is being torn down; `copy.copy()` on that
item raises `RuntimeError: Signal source has been deleted`, which unwinds
through `_reindex()` -> `applyFilter()` and aborts the deletion. The
exception is swallowed, so the UI just does nothing.

### Fix
Reindexing/filtering an index->item map must keep the *same* item objects,
never copy them. `copyFrom` now references values by default; `deep=True`
still deep-copies for the rare caller that wants an independent copy.

### Testing
Open a container, click delete, confirm. Before: nothing happens, log shows
"Signal source has been deleted". After: the container is removed.