### PR TITLE
Initialize ModeDeviceTabWidget._filter to avoid AttributeError

### DIFF
--- a/gremlin/ui/mode_device.py
+++ b/gremlin/ui/mode_device.py
@@ -312,6 +312,7 @@ class ModeDeviceTabWidget(gremlin.input_item.BaseDeviceTabWidget):
 
         self.current_mode = mode
         self.widget_storage = {}
+        self._filter = ""  # active search filter string (empty = no filtering)
 
         el = gremlin.event_handler.EventListener()
         el.profile_loaded.connect(self._handle_new_profile)


### PR DESCRIPTION
### Problem
AttributeError: 'ModeDeviceTabWidget' object has no attribute '_filter',
triggered when the model filter runs (e.g. stopping a profile).

### Cause
`_filter_data()` reads `self._filter` (lines ~432/441/443) but it is never
assigned anywhere in the class.

### Fix
Initialize `self._filter = ""` in __init__. Empty means "no filtering",
which is the intended default (there is no search box wired to this class).