### PR TITLE
Fix tempo short-press crash on release without a matching press

### DIFF
--- a/container_plugins/tempo/__init__.py
+++ b/container_plugins/tempo/__init__.py
@@ -340,17 +340,24 @@ class TempoContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
                 if self.timer:
                     self.timer.cancel()
                     self.timer = None
-                thread = threading.Thread(
-                    target=lambda: self._short_press(
-                        self.event_press,  # send a press event to the functors
-                        self.value_press,
-                        event,
-                        value,
-                    ),
-                    daemon=False,
-                )
-                thread.name = "TEMPO short"
-                thread.start()
+                # Only fire the short press if we actually recorded the matching
+                # press on this functor instance. After a mode switch a new tempo
+                # instance can receive a release whose press was handled by the
+                # previous mode's instance, leaving event_press as None; firing
+                # then sends None events downstream (crashes in execute_node /
+                # play_sound with 'NoneType' has no attribute ...).
+                if self.event_press is not None:
+                    thread = threading.Thread(
+                        target=lambda: self._short_press(
+                            self.event_press,  # send a press event to the functors
+                            self.value_press,
+                            event,
+                            value,
+                        ),
+                        daemon=False,
+                    )
+                    thread.name = "TEMPO short"
+                    thread.start()
 
             self.trigger_mode = None
 


### PR DESCRIPTION
### Problem
A tempo container on a button that also switches modes throws, in a
"TEMPO short" thread: 'NoneType' object has no attribute 'mode' (and
'is_pressed'). The exception is in a worker thread so the app keeps running,
but the short press misfires.

### Cause
`self.event_press` is set only on press. After a mode switch, a fresh tempo
instance in the new mode gets the *release* while the *press* was seen by
the old mode's instance, so event_press is still None and the short-press
thread forwards None events.

### Fix
Guard the short-press firing on `self.event_press is not None`. A release
without a recorded press is a no-op.