### PR TITLE
Don't crash profile launch on an incomplete TempoEx container

### DIFF
--- a/container_plugins/tempoEx/__init__.py
+++ b/container_plugins/tempoEx/__init__.py
@@ -600,7 +600,20 @@ class TempoExContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
         self.verbose = gremlin.config.Configuration().verbose_mode_container
 
 
-        assert len(self.container.action_sets) == 3, "TempoEx container must have exactly 3 action sets: short, long, and double."
+        # A TempoEx container needs exactly 3 action sets (short, long, double).
+        # A container that is still being configured in the editor may not have
+        # them all yet; that is a normal transient state, not a fatal error.
+        # Disable this container for the run instead of raising (a bare assert
+        # here propagates through the profile_started signal emission and aborts
+        # the whole profile launch, taking the UI down with it).
+        if len(self.container.action_sets) != 3:
+            syslog.warning(
+                f"TEMPOEX: Disabled: container needs exactly 3 action sets "
+                f"(short, long, double), found {len(self.container.action_sets)} "
+                f"- container is likely still being configured. id: [{self.container.id}]"
+            )
+            self.valid = False
+            return
 
 
         self.last_trigger = None


### PR DESCRIPTION
### Problem
Launching a profile while a TempoEx container is mid-configuration crashes
the launch (AssertionError -> psygnal EmitLoopError), and the editor UI
becomes unstable.

### Cause
`profile_started` uses `assert len(action_sets) == 3`. An in-progress
container legitimately has fewer, and the assert is fatal.

### Fix
Replace the assert with a graceful disable (warn, set self.valid = False,
return) — the same pattern used elsewhere in this plugin. The container is
skipped for the run and works once fully configured.