### PR TITLE
Guard against None event in execute_node mode check

### DIFF
--- a/gremlin/execution_graph.py
+++ b/gremlin/execution_graph.py
@@ -1924,7 +1924,7 @@ class ExecutionContext:
             logTabs = gremlin.shared_state.logTabs()
 
             # abort if the mode changed and the event was fired in a different mode
-            if event.mode and event.mode not in (gremlin.shared_state.runtime_mode, gremlin.shared_state.master_mode):
+            if event is not None and event.mode and event.mode not in (gremlin.shared_state.runtime_mode, gremlin.shared_state.master_mode):
                 if verbose_exec:
                     syslog.info(
                         f"{logTabs}EXEC:[{node.id}] [{node.nodeType.name}] {node.description} - ignoring event due to wrong mode {event.mode} current runtime: {gremlin.shared_state.runtime_mode} "


### PR DESCRIPTION
### Problem
'NoneType' object has no attribute 'mode' in execute_node, reached from a
tempo container's worker thread.

### Cause
`if event.mode and ...` runs without verifying `event is not None`.

### Fix
`if event is not None and event.mode and ...`. Defensive: an execution node
should not crash on a null event. (The root cause of the null event is
fixed separately in the tempo container; this guard is belt-and-braces.)