### PR TITLE
Fix vJoy display names and map_to_osc_ex axis_names KeyError

### DIFF
--- a/action_plugins/map_to_osc_ex/__init__.py
+++ b/action_plugins/map_to_osc_ex/__init__.py
@@ -237,7 +237,7 @@ class OscArg(QtCore.QObject):
             if self._source_device_id and self._source_axis_id is not None:
                 device = gremlin.joystick_handling.getDevice(self._source_device_id)
                 if device:
-                    axis_name = device.axis_names[self._source_axis_id - 1]
+                    axis_name = device.axis_names.get(self._source_axis_id, f"Axis {self._source_axis_id}")
                 else:
                     axis_name = f"unknown device [{self._source_device_id}] Source Axis: [{self._source_axis_id - 1}]"
                 comment_node = ElementTree.Comment(f" Source device: {device.name} Source axis: {axis_name} ")

--- a/gremlin/joystick_handling.py
+++ b/gremlin/joystick_handling.py
@@ -1289,7 +1289,7 @@ def _create_vjoy_device(vjoy_index: int):
     device.axismap_list = []
     device.usage_page = None
     device.usage = None
-    device.axis_names = []
+    device.axis_names = {}
     return device
 
 
@@ -1488,6 +1488,7 @@ def joystick_devices_initialization():
             vjoy_proxy = VJoyProxy()
             config_map = {}
             disconnected_list = []
+            unconfigured_indices = set()
             used_counts = []
 
             for vjoy_index in range(1, 17):  # index 1 up to 16
@@ -1517,8 +1518,7 @@ def joystick_devices_initialization():
 
                     else:
                         device: DeviceSummary = dinput_vjoy_device_map[dinput_key]
-                        device.vjoy_id = vjoy_index
-                        device.virtual_id = vjoy_index
+                        device.set_vjoy_id(vjoy_index)
                         device.setConnected(True)  # connected means the VJOY device is not only shown in the API but also with DINPUT.
                         syslog.info(f"VJOY device [{vjoy_index}] matched to DINPUT device [{device.device_id}]")
                         _all_vjoy_devices_map[vjoy_index] = device
@@ -1526,12 +1526,13 @@ def joystick_devices_initialization():
                         _joystick_device_guid_map[device.device_guid] = device  # key by GUID
                         _all_devices_map[device.device_guid] = device  # key by GUID
                 else:
-                    # device reports as not available from the vjoy interface
+                    # slot exists in the vJoy range (1-16) but is not configured in vJoyConf
                     disconnected_list.append(vjoy_index)
+                    unconfigured_indices.add(vjoy_index)
                     device = _create_vjoy_device(vjoy_index)
                     _all_vjoy_devices_map[vjoy_index] = device
                     _joystick_device_guid_map[device.device_guid] = device  # key by GUID
-                    _all_devices_map[device.device_guid] = device
+                    # keep unconfigured placeholders out of the UI device list
 
                     if verbose:
                         syslog.warning(f"VJOY device [{vjoy_index}] is not detected or not enabled in the VJOY API. This VJOY will be disabled.")
@@ -1546,7 +1547,8 @@ def joystick_devices_initialization():
                 device = _all_vjoy_devices_map[vjoy_index]
                 device.button_count = count  # update unique button count for disconnected devices
                 device.name = f"Vjoy {device.axis_count}/{device.button_count}/{device.hat_count} ({vjoy_index})"
-                if device.device_guid not in _all_devices_map:
+                # unconfigured slots stay internal-only; HIDHide / missing-DINPUT devices remain listed
+                if vjoy_index not in unconfigured_indices and device.device_guid not in _all_devices_map:
                     _all_devices_map[device.device_guid] = device
 
 
@@ -1611,7 +1613,7 @@ def joystick_devices_initialization():
                         axis_name = f"({i + 1})"
                     else:
                         logical_count += 1
-                    dev.axis_names.append(axis_name)
+                    dev.axis_names[axis_map.axis_index] = axis_name
 
                 vjoy_lookup[hash_value] = dev
                 _all_joystick_devices.append(dev)

--- a/gremlin/ui/axis_calibration.py
+++ b/gremlin/ui/axis_calibration.py
@@ -970,7 +970,9 @@ class CalibrationDialogEx(QtWidgets.QDialog):
         self.setWindowTitle("Input Axis Calibration")
         info = gremlin.joystick_handling.getDevice(device_guid)
         axis_id = info.getAxisLinearId(input_id)
-        self.main_layout.addWidget(QtWidgets.QLabel(f"{info.name} Axis: {info.axis_names[axis_id - 1]}/L{axis_id}"))
+        axis_index = info.linear_id_map.get(axis_id, axis_id)
+        axis_name = info.axis_names.get(axis_index, f"Axis {axis_id}")
+        self.main_layout.addWidget(QtWidgets.QLabel(f"{info.name} Axis: {axis_name}/L{axis_id}"))
         self.main_layout.addWidget(
             QtWidgets.QLabel("Note: Calibration options will apply to the computed input data value before any other parts of GremlinEx process the input.")
         )

--- a/gremlin/ui/input_viewer.py
+++ b/gremlin/ui/input_viewer.py
@@ -34,7 +34,7 @@ import gremlin.util
 from gremlin.util import safe_read
 from gremlinEx import DeviceSummary
 from . import ui_common
-from gremlin.types import VisualizationType
+from gremlin.types import DeviceType, VisualizationType
 import os
 from lxml import etree
 import gremlin.singleton_decorator
@@ -1093,6 +1093,9 @@ States can be toggled by clicking on the state button.  Expression states will u
 
         for device in devices:
             if device.disabled:
+                continue
+            # Unconfigured vJoy slots (13-16 when only 1-12 exist) are internal placeholders.
+            if device.device_type == DeviceType.VJoy and not device.connected:
                 continue
             if verbose:
                 syslog.info(

--- a/gremlin/ui/ui_common.py
+++ b/gremlin/ui/ui_common.py
@@ -3287,7 +3287,7 @@ class AbstractInputSelector(QWidget):
                         input_id = i + 1
                         if input_type == InputType.JoystickAxis:
                             input_id = device.axismap_list[i].axis_index
-                            s_ui = f"Axis {device.axis_names[i]}"
+                            s_ui = f"Axis {device.axis_names.get(input_id, input_id)}"
                         else:
                             s_ui = gremlin.common.input_to_ui_string(input_type, input_id)
                         selection_widget.addItem(s_ui, (input_type, input_id))
@@ -7301,7 +7301,7 @@ class AxesTimeline(QtWidgets.QGroupBox):
         colors = Color.PenColors()
         for i in range(device.axis_count):
             index = device.axismap_list[i].axis_index
-            axis_name = device.axis_names[i]
+            axis_name = device.axis_names.get(index, f"Axis {index}")
             label = QtWidgets.QLabel(f"Axis {axis_name}")
             css = f"QLabel {{ color: {colors.get(index, '#000000')}; font-weight: bold }}"
             label.setStyleSheet(css)
@@ -12869,7 +12869,8 @@ class QAxisSourceSelector(QWidget):
                 count = device.axis_count
                 self._axis_selector_widget.clear()
                 for id in range(1, count + 1):
-                    axis_name = device.axis_names[id - 1]
+                    axis_index = device.linear_id_map.get(id, id)
+                    axis_name = device.axis_names.get(axis_index, f"Axis {id}")
                     self._axis_selector_widget.addItem(f"Axis {axis_name}", id)
 
             if input_id is not None:


### PR DESCRIPTION
## Summary
- Restore expanded vJoy names (`VJoy 8/101/0 (1)`) by calling `set_vjoy_id()` after a successful DINPUT match, and keep unconfigured vJoyConf slots (e.g. 13–16) out of the UI device list.
- Fix `map_to_osc_ex` profile load crash (`KeyError: 0`) after `axis_names` changed from a list to a dict keyed by `axis_index`; update the same lookup pattern in axis calibration and UI axis selectors.

## Test plan
- [ ] With 12 configured vJoy devices (unused slots 13–16), confirm tabs and Input Viewer show 12 entries named `VJoy 8/<buttons>/<hats> (<id>)` and no extra 13–16 placeholders.
- [ ] Confirm a profile that previously crashed on load with `map_to_osc_ex` `KeyError: 0` now loads.
- [ ] Open axis calibration and axis source selectors and confirm axis labels still resolve.

Made with [Cursor](https://cursor.com)