### PR TITLE
Fix vJoy-as-input device tab labels

### DIFF
--- a/gremlin/joystick_handling.py
+++ b/gremlin/joystick_handling.py
@@ -1520,8 +1520,7 @@ def joystick_devices_initialization():
 
                     else:
                         device: DeviceSummary = dinput_vjoy_device_map[dinput_key]
-                        device.vjoy_id = vjoy_index
-                        device.virtual_id = vjoy_index
+                        device.set_vjoy_id(vjoy_index)
                         device.setConnected(True)  # connected means the VJOY device is not only shown in the API but also with DINPUT.
                         syslog.info(f"VJOY device [{vjoy_index}] matched to DINPUT device [{device.device_id}]")
                         _all_vjoy_devices_map[vjoy_index] = device

--- a/gremlinEx.py
+++ b/gremlinEx.py
@@ -541,10 +541,7 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
 
     def _get_device_name(self, device_guid):
         """gets the name of a device"""
-        device = self._get_device(device_guid)
-        if device:
-            return device.name
-        return None
+        return gremlin.joystick_handling.getDeviceName(device_guid)
 
     def _add_tab(self, device_guid, tab_type, index=None, override_name=None) -> int:
         """adds a tab to the tab header
@@ -558,7 +555,7 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
         if not device:
             syslog.error(f"Unknown device GUID found in tabs: {device_guid}")
             return
-        device_name = device.name
+        device_name = gremlin.joystick_handling.getDeviceName(device_guid)
 
         # ensure the device tab does not already exist
         if device_guid in self._tab_device_map:
@@ -3053,7 +3050,7 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
                     # Create vJoy as input device tabs
 
                     device_guid = gremlin.util.normalize_guid(device.device_guid)
-                    device_name = device.name
+                    device_name = gremlin.joystick_handling.getDeviceName(device.device_guid)
                     input_enabled = self.profile.settings._vjoy_as_input.get(device.vjoy_id, False)
 
                     if not input_enabled:


### PR DESCRIPTION
## Summary
- Connected vJoy devices keep the raw DINPUT name (`vJoy Device`) because matching sets `vjoy_id` without calling `set_vjoy_id()`.
- Input Viewer already shows expanded names via `getDeviceName()`; device tabs still used `device.name`.
- Call `set_vjoy_id()` on a successful DINPUT match, and use `getDeviceName()` when creating vJoy-as-input tabs.

## Test plan
- [ ] Enable one or more vJoy devices as input.
- [ ] Confirm device tabs show names like `VJoy 8/101/0 (1)` instead of `vJoy Device`.
- [ ] Confirm Input Viewer still shows the same expanded names.
- [ ] Confirm unused/unconfigured vJoy slots do not break tab creation.

Made with [Cursor](https://cursor.com)