### PR TITLE
Fix hard crash when a sound or TTS action is triggered while audio is still playing

### DIFF
--- a/gremlin/sound.py
+++ b/gremlin/sound.py
@@ -691,15 +691,36 @@ class Sound:
         self._initialized = True
 
 
+    def _has_active_audio(self) -> bool:
+        """true if any audio stream is currently playing"""
+        if not USE_SD:
+            return False
+        self._task_trim()
+        with self._tasks_lock:
+            return bool(self._sound_tasks)
+
     def _update_devices(self):
         """ updates the sound devices list """
         verbose = gremlin.config.Configuration().verbose_mode_sound
         # verbose = True
         # force an update
         if self._initialized:
-            # re-init
-            sd._terminate()
-            sd._initialize()
+            # Re-initializing PortAudio tears down its global library state,
+            # including any live output stream. Doing that while audio is
+            # playing kills the process at the native level with no Python
+            # traceback. This is hit whenever a TTS or sound action is
+            # triggered again before the previous one has finished playing,
+            # because the default-device lookup on the playback path calls
+            # this method. Only re-initialize when nothing is playing;
+            # refreshing the device list on its own is safe.
+            if self._has_active_audio():
+                if verbose:
+                    syslog.info(
+                        "AUDIO: playback in progress - skipping device re-initialization"
+                    )
+            else:
+                sd._terminate()
+                sd._initialize()
             self.device_map.clear()
             self.device_name_to_id_map.clear()
             self.device_sample_rate_map.clear()


### PR DESCRIPTION
### Problem

Since m77T44, triggering a TTS or sound action while a previous one is still
playing kills the application instantly. The process dies at the native level:
no Python traceback, no shutdown sequence in the log, nothing after the last
INFO line. Letting a phrase finish before triggering the next one never crashes.

### Root cause

`Sound._update_devices()` calls `sd._terminate()` followed by `sd._initialize()`
whenever it runs after construction. These tear down and rebuild PortAudio's
global library state, including any live output stream. Doing that while a
stream is playing is an invalid access and takes the process down.

This is reached on the normal playback path whenever the configured audio
device is the default one:

sound/TTS action triggered
      -> playback_default is True
      -> getDefaultAudioDeviceName()      (action_plugins/play_sound/__init__.py)
      -> Sound._update_devices()          (gremlin/sound.py)
      -> sd._terminate()                  <- crash if a stream is live


`getDefaultAudioDevice()` has the same call into `_update_devices()`.

Before m77T44 these accessors only queried PortAudio; they did not
re-initialize it.

### Fix

Only re-initialize PortAudio when no audio stream is active. When playback is
in progress, the device list is still refreshed (which is safe on its own) and
the re-initialization is skipped; it will happen on the next lookup once
nothing is playing.

Adds a small `_has_active_audio()` helper that reuses the existing
`_sound_tasks` list and `_tasks_lock`.

The intent of the original change - picking up audio device changes at runtime -
is preserved.

### Testing

Reproduced reliably before the fix by triggering two TTS actions in quick
succession (default audio device, Windows, Python 3.14.5). After the fix the
second trigger plays normally; with verbose sound logging enabled the skipped
re-initialization is logged instead of crashing.