### PR TITLE
Guard against unknown device guid in verbose vJoy logging

### DIFF
--- a/gremlin/event_handler.py
+++ b/gremlin/event_handler.py
@@ -4055,13 +4055,17 @@ class JoystickState:
     def setInputEnabled(self, device_guid, enabled: bool):
         """marks a device as input ingnored"""
         import gremlin.config
+        import gremlin.joystick_handling
 
         verbose = gremlin.config.Configuration().verbose_mode_vjoy
         if not isinstance(device_guid, str):
             device_guid = gremlin.util.normalize_guid(device_guid)
         if verbose:
-            device = gremlin.joystick_handling.getDevice(device_guid)
-            syslog.info(f"VJOY: {device.name} input: {'off' if enabled else 'on'}")
+            # getDevice() returns None when the guid is not in the device
+            # registry; getDeviceName() handles that and reports the guid
+            # instead, so verbose logging can never crash profile load.
+            device_name = gremlin.joystick_handling.getDeviceName(device_guid)
+            syslog.info(f"VJOY: {device_name} input: {'off' if enabled else 'on'}")
         self._input_ignored_device_list[device_guid] = not enabled
         if verbose:
             syslog.info("VJOY ")
@@ -4075,9 +4079,11 @@ class JoystickState:
         if not isinstance(device_guid, str):
             device_guid = gremlin.util.normalize_guid(device_guid)
         self._output_ignored_device_list[device_guid] = not enabled
-        device = gremlin.joystick_handling.getDevice(device_guid)
         if verbose:
-            syslog.info(f"VJOY: {device.name} output: {'off' if enabled else 'on'}")
+            # getDevice() can return None for an unknown guid - use the
+            # name helper which reports the guid instead of raising.
+            device_name = gremlin.joystick_handling.getDeviceName(device_guid)
+            syslog.info(f"VJOY: {device_name} output: {'off' if enabled else 'on'}")
 
     def _vjoy_as_input_changed(self, vjoy_id: int, enabled: bool):
         dev = gremlin.joystick_handling.vjoy_info_from_vjoy_id(vjoy_id)


### PR DESCRIPTION
### Problem

With `verbose_mode_vjoy` enabled, loading a profile can abort with:

AttributeError: 'NoneType' object has no attribute 'name'
      File "gremlin/event_handler.py", line 4064, in setInputEnabled
        syslog.info(f"VJOY: {device.name} input: ...")


The exception propagates out of the profile load worker and the profile fails
to load.

### Root cause

`setInputEnabled()` and `setOutputEnabled()` both call
`gremlin.joystick_handling.getDevice()` and dereference `.name` directly.
`getDevice()` is documented to return `None` when the guid is not in the
device registry, and `getDeviceName()` right below it already handles that
case.

Both accesses sit inside `if verbose:` blocks, so this only affects users
running with verbose vJoy logging on - which is why it has not shown up more
widely.

### Fix

Use the existing `getDeviceName()` helper in both log statements. It returns
`unknown: <guid>` for an unresolved guid, so verbose logging degrades to a
useful diagnostic instead of aborting the profile load.

Also adds the missing local `import gremlin.joystick_handling` to
`setInputEnabled()`, for consistency with `setOutputEnabled()` - the module was
previously relied on being imported elsewhere.

### Note

This fixes the crash, not the reason the guid fails to resolve. A physical
device present at startup was not found in the registry during
`reset()`, which suggests a round-trip issue between `normalize_guid()` and
`to_guid()`. With this change the offending guid is logged rather than
swallowed, which should make that easier to track down.

Possibly related, in `reset()`: the IFR1 branch passes the raw
`dev.device_guid` to `setInputEnabled()` but the normalized `device_guid` to
`setOutputEnabled()`.