### PR TITLE
Fix double-conversion of runtime activation conditions

### DIFF
--- a/gremlin/actions.py
+++ b/gremlin/actions.py
@@ -922,6 +922,12 @@ def convert_condition(condition):
     import gremlin.ui.state_device
     import gremlin.actions
     import gremlin.input_item
+
+    # Already a runtime condition (e.g. VirtualButtonCondition created during
+    # tree build) — converting again would fail the type checks below.
+    if isinstance(condition, AbstractCondition):
+        return condition
+
     if isinstance(condition, gremlin.ui.keyboard_device.BaseKeyboardCondition):
         return gremlin.actions.KeyboardCondition(condition.scan_code, condition.is_extended, condition.comparison, input_item = condition.input_item, target = condition.target)
 

--- a/gremlin/execution_graph.py
+++ b/gremlin/execution_graph.py
@@ -1237,6 +1237,9 @@ class ExecutionContext:
                         if condition and container:
                             if isinstance(condition, gremlin.input_item.BaseActivationCondition):
                                 functor = self._create_activation_condition(condition, container, True)
+                            elif isinstance(condition, gremlin.actions.AbstractCondition):
+                                # Already a runtime functor (e.g. VirtualButtonCondition)
+                                functor = condition
                             else:
                                 functor = self._convert_condition(condition)
                             logtabs = gremlin.shared_state.logTabs()


### PR DESCRIPTION
## Summary
- Skips reconverting conditions that are already runtime `AbstractCondition` instances (e.g. `VirtualButtonCondition` built during execution-graph construction).
- Prevents assert/failure in `convert_condition` and lets activation conditions evaluate correctly.

## Test plan
- [ ] Activate a profile that uses virtual-button (or other already-converted) activation conditions
- [ ] Confirm containers with those conditions execute as expected
- [ ] Confirm normal joystick/keyboard/state conditions still convert and run