### PR TITLE
Restore gated vJoy-as-input loopback (axis/button/hat)

### DIFF
--- a/gremlin/event_handler.py
+++ b/gremlin/event_handler.py
@@ -1502,7 +1502,7 @@ class EventListener(QtCore.QObject):
         vjoy_id = vjoyevent.vjoy_id
         verbose = self._verbose_vjoy
         # verbose = True # debug mode - force output for diagnostics regardless of user settings
-        if self._profile_started and self.js.vjoyAsInput(vjoy_id):
+        if self._profile_started and self.js.getVjoyAsInput(vjoy_id):
             # profile is running and started, and the vjoy device is a loopback device (used as input)
             input_type = vjoyevent.input_type
             input_id = vjoyevent.input_id

--- a/vjoy/vjoy.py
+++ b/vjoy/vjoy.py
@@ -278,15 +278,8 @@ class Axis:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-        # Synthetic loopback for "vJoy as input". DINPUT often does not echo our
-        # own SetAxis back into GEX; vjoy_event feeds EventListener._handle_vjoy_event
-        # which queues a real input event for mappings on this device.
-        axis_input_id = self.axis_id - 0x30 + 1
-        el.vjoy_event.emit(
-            gremlin.event_handler.VjoyEvent(
-                self.vjoy_id, InputType.JoystickAxis, axis_input_id, self._value
-            )
-        )
+        # Do not emit vjoy_event for axes (m76T185 / T139+). High-rate axis
+        # samples flooding the loopback path cause severe input lag.
 
 
 
@@ -380,9 +373,9 @@ class Button:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-        # Synthetic loopback for "vJoy as input". UI output events alone do not
-        # drive profile mappings; emit vjoy_event so _handle_vjoy_event can
-        # queue input when this device is used as input.
+        # Synthetic loopback for "vJoy as input". m76T185 only emitted
+        # vjoy_output_event (UI) for buttons; DINPUT echo is unreliable, so emit
+        # vjoy_event for buttons (low rate) so mappings on this device fire.
         el.vjoy_event.emit(
             gremlin.event_handler.VjoyEvent(
                 self.vjoy_id, InputType.JoystickButton, self.button_id, is_pressed
@@ -569,7 +562,7 @@ class Button:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-        # Synthetic loopback for "vJoy as input" (same path as axis/button).
+        # Synthetic loopback for "vJoy as input" (m76T185 hat path).
         el.vjoy_event.emit(
             gremlin.event_handler.VjoyEvent(
                 self.vjoy_id, InputType.JoystickHat, self.hat_id, direction

--- a/vjoy/vjoy.py
+++ b/vjoy/vjoy.py
@@ -278,9 +278,6 @@ class Axis:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-        # Do not emit vjoy_event for axes (m76T185 / T139+). High-rate axis
-        # samples flooding the loopback path cause severe input lag.
-
 
 
 
@@ -373,14 +370,21 @@ class Button:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-        # Synthetic loopback for "vJoy as input". m76T185 only emitted
-        # vjoy_output_event (UI) for buttons; DINPUT echo is unreliable, so emit
-        # vjoy_event for buttons (low rate) so mappings on this device fire.
-        el.vjoy_event.emit(
-            gremlin.event_handler.VjoyEvent(
-                self.vjoy_id, InputType.JoystickButton, self.button_id, is_pressed
+        # Loopback only for "vJoy as input" devices (button chaining). Not emitted
+        # for normal output-only vJoy writes.
+        import gremlin.shared_state
+        profile = gremlin.shared_state.current_profile
+        if profile is not None and profile.settings.getVjoyAsInput(self.vjoy_id):
+            el.vjoy_event.emit(
+                gremlin.event_handler.VjoyEvent(
+                    self.vjoy_id, InputType.JoystickButton, self.button_id, is_pressed
+                )
             )
-        )
+
+
+
+
+class Hat:
     """Represents a discrete hat in vJoy, allows setting the direction
     of the hat."""
 
@@ -562,12 +566,19 @@ class Button:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-        # Synthetic loopback for "vJoy as input" (m76T185 hat path).
-        el.vjoy_event.emit(
-            gremlin.event_handler.VjoyEvent(
-                self.vjoy_id, InputType.JoystickHat, self.hat_id, direction
+        # m76T185 hat loopback, gated to vJoy-as-input devices only.
+        import gremlin.shared_state
+        profile = gremlin.shared_state.current_profile
+        if profile is not None and profile.settings.getVjoyAsInput(self.vjoy_id):
+            el.vjoy_event.emit(
+                gremlin.event_handler.VjoyEvent(
+                    self.vjoy_id, InputType.JoystickHat, self.hat_id, direction
+                )
             )
-        )
+
+
+
+        vjm = VJoyMonitor()
         vjm.ensure_ownership(self.vjoy_id)
 
         if self.hat_type == HatType.Discrete:

--- a/vjoy/vjoy.py
+++ b/vjoy/vjoy.py
@@ -278,6 +278,16 @@ class Axis:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
+        # Synthetic loopback for "vJoy as input". DINPUT often does not echo our
+        # own SetAxis back into GEX; vjoy_event feeds EventListener._handle_vjoy_event
+        # which queues a real input event for mappings on this device.
+        axis_input_id = self.axis_id - 0x30 + 1
+        el.vjoy_event.emit(
+            gremlin.event_handler.VjoyEvent(
+                self.vjoy_id, InputType.JoystickAxis, axis_input_id, self._value
+            )
+        )
+
 
 
 
@@ -370,10 +380,14 @@ class Button:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-
-
-
-class Hat:
+        # Synthetic loopback for "vJoy as input". UI output events alone do not
+        # drive profile mappings; emit vjoy_event so _handle_vjoy_event can
+        # queue input when this device is used as input.
+        el.vjoy_event.emit(
+            gremlin.event_handler.VjoyEvent(
+                self.vjoy_id, InputType.JoystickButton, self.button_id, is_pressed
+            )
+        )
     """Represents a discrete hat in vJoy, allows setting the direction
     of the hat."""
 
@@ -555,9 +569,12 @@ class Hat:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-
-
-        vjm = VJoyMonitor()
+        # Synthetic loopback for "vJoy as input" (same path as axis/button).
+        el.vjoy_event.emit(
+            gremlin.event_handler.VjoyEvent(
+                self.vjoy_id, InputType.JoystickHat, self.hat_id, direction
+            )
+        )
         vjm.ensure_ownership(self.vjoy_id)
 
         if self.hat_type == HatType.Discrete:


### PR DESCRIPTION
## Summary
- Emits synthetic `vjoy_event` for **axis/button/hat** writes only when that device has **vJoy as input** enabled (`getVjoyAsInput`).
- Needed so mappings on the vJoy tab (e.g. Map to OSC Ex on a vJoy axis) fire when GEX itself writes the device — DINPUT echo is unreliable.
- Updates `_handle_vjoy_event` to use `getVjoyAsInput` after the `vjoyAsInput` rename.
- Restores `class Hat` (was accidentally dropped in an earlier loopback commit).

## Test plan
- [ ] Mark a vJoy device as input; put Map to OSC Ex on a **vJoy axis** with Device sources on that device
- [ ] Drive merges/remaps that write those axes — OSC messages should send
- [ ] Button/hat chaining on vJoy-as-input still works
- [ ] With vJoy-as-input **off**, writes should not fire input mappings
- [ ] Keep verbose off while checking latency on heavy merge profiles
