### PR TITLE
Persist QColorDialog custom colors across sessions

### DIFF
--- a/action_plugins/virpil_led/__init__.py
+++ b/action_plugins/virpil_led/__init__.py
@@ -638,6 +638,13 @@ class VirpilButtonWidget(QtWidgets.QWidget):
 
     def _pick_color(self, current_rgb: int, title: str) -> int | None:
         color = QColor.fromRgb(current_rgb)
+        # Qt keeps the custom color palette in process-global state, so it has to be
+        # restored before the dialog opens and harvested after it closes.
+        config = gremlin.config.Configuration()
+        slot_count = QColorDialog.customCount()
+        for index, rgb in enumerate(config.custom_colors[:slot_count]):
+            QColorDialog.setCustomColor(index, QColor.fromRgb(rgb))
+
         # Use Qt's dialog, not the Windows native one. Native "Add to Custom Colors"
         # always overwrites the selected (usually first) custom slot.
         selected = QColorDialog.getColor(
@@ -646,6 +653,9 @@ class VirpilButtonWidget(QtWidgets.QWidget):
             title=title,
             options=QColorDialog.ColorDialogOption.DontUseNativeDialog,
         )
+
+        config.custom_colors = [QColorDialog.customColor(index).rgb() for index in range(slot_count)]
+
         if selected.isValid():
             return selected.rgb()
         return None

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -721,6 +721,16 @@ class Configuration(QtCore.QObject):
     def reset_mode_on_process_activate(self, value):
         self._set_data("reset_mode_on_process_activate", value)
 
+    @property
+    def custom_colors(self) -> list[int]:
+        """custom color palette shared by the color pickers, as RGB integers"""
+        data = self._get_data("custom_colors", [])
+        return [int(rgb) for rgb in data] if data else []
+
+    @custom_colors.setter
+    def custom_colors(self, value: list[int]):
+        self._set_data("custom_colors", [int(rgb) for rgb in value])
+
     def set_calibration(self, dev_id, limits):
         """Sets the calibration data for all axes of a device.
 


### PR DESCRIPTION
## Summary
- Qt's custom color slots are process-global only; Virpil LED On/Off/Blink pickers lost user custom colors after restart.
- Persist the palette in app config (`Configuration.custom_colors`), restore into `QColorDialog` before open, and write back after close.
- Continues using the non-native dialog so `Add to Custom Colors` does not overwrite the first slot.

## Test plan
- [ ] Open a Virpil LED action color picker, add colors to the custom palette, pick a color
- [ ] Restart Gremlin Ex and reopen the picker — custom slots should still be there
- [ ] Confirm On/Off/Blink color selection still works

Made with [Cursor](https://cursor.com)