### PR TITLE
Emit gated axis vjoy_event for vJoy-as-input devices

### DIFF
--- a/vjoy/vjoy.py
+++ b/vjoy/vjoy.py
@@ -278,8 +278,20 @@ class Axis:
         el.vjoy_output_event.emit(event)
         el.vjoy_output_event_ui.emit(event)
 
-
-
+        # Loopback only for "vJoy as input" devices. Needed so mappings on the
+        # vJoy tab (e.g. Map to OSC Ex) fire when GEX writes the axis — DINPUT
+        # echo is unreliable. Gated to avoid flooding normal output-only devices.
+        import gremlin.shared_state
+        profile = gremlin.shared_state.current_profile
+        if profile is not None and profile.settings.getVjoyAsInput(self.vjoy_id):
+            el.vjoy_event.emit(
+                gremlin.event_handler.VjoyEvent(
+                    self.vjoy_id,
+                    InputType.JoystickAxis,
+                    self.axis_id - 0x30 + 1,
+                    self._value,
+                )
+            )
 
     def set_absolute_value(self, value):
         """Sets the position of the axis based on a value between [-1, 1].


### PR DESCRIPTION
## Summary
- Follow-up to #485: that PR was merged before the gated **axis** `vjoy_event` commit landed.
- Emits synthetic `vjoy_event` for axis writes only when the device has **vJoy as input** enabled (`getVjoyAsInput`).
- Needed so mappings on the vJoy tab (e.g. Map to OSC Ex) fire when GEX itself writes the axis — DINPUT echo is unreliable.
- Button/hat gating from #485 is unchanged; output-only vJoy devices stay quiet.

## Test plan
- [ ] Mark a vJoy device as input; put Map to OSC Ex on a **vJoy axis** with Device sources on that device
- [ ] Drive merges/remaps that write those axes — OSC messages should send
- [ ] With vJoy-as-input **off**, axis writes should not fire input mappings
- [ ] Keep verbose off while checking latency on heavy merge profiles
- [ ] Spot-check button/hat vJoy-as-input chaining still works
