### PR TITLE
Remove accidental torch import breaking startup

### DIFF
--- a/gremlin/base_profile.py
+++ b/gremlin/base_profile.py
@@ -30,8 +30,6 @@ import time
 
 from typing import Callable
 
-from torch import mode
-
 import container_plugins
 import gremlin.keyboard
 import gremlin.profile


### PR DESCRIPTION
Description :

markdown
### Problem

The application fails to start with:

ModuleNotFoundError: No module named 'torch' File "gremlinex.py", line 70, in <module> import gremlin.profile_graph File "gremlin/profile_graph.py", line 48, in <module> import gremlin.base_profile File "gremlin/base_profile.py", line 33, in <module> from torch import mode


### Root cause

`from torch import mode` was added to `gremlin/base_profile.py` in m77T46 WIP
(2481bc5c). It looks like an accepted IDE auto-import suggestion for the name
`mode`. PyTorch is not a dependency of the project and the imported symbol is
never used - `torch` appears exactly once in the file, on the import line.

The problem is invisible on a machine that happens to have torch installed,
but blocks startup for everyone else.

### Fix

Remove the import.