### PR TITLE
Initialize TempoContainerFunctor.verbose to fix profile start crash

### DIFF
--- a/container_plugins/tempo/__init__.py
+++ b/container_plugins/tempo/__init__.py
@@ -26,6 +26,7 @@ from lxml import etree as ElementTree
 from PySide6 import QtWidgets, QtCore
 
 import gremlin
+import gremlin.config
 import gremlin.ui.ui_common
 from gremlin.input_item import AbstractContainer, AbstractContainerWidget, ActionSelector, ActionSet, InputItem
 from gremlin.input_types import InputType
@@ -253,6 +254,10 @@ class TempoContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
         self.short_nodes = []
         self.trigger_mode = None
         self._thread = None
+        # profile_started() logs node counts under this flag; it was read
+        # but never initialized, so starting a profile containing a Tempo
+        # container raised AttributeError. Mirrors the TempoEx functor.
+        self.verbose = gremlin.config.Configuration().verbose_mode_container
 
     def profile_started(self):
         # reset any prior values before start


### PR DESCRIPTION
### Problem

Starting a profile that contains a Tempo container aborts with:

AttributeError: 'TempoContainerFunctor' object has no attribute 'verbose' File "container_plugins/tempo/init.py", line 307, in profile_started if self.verbose:


The exception is raised from the `profile_started` signal callback, so the
profile cannot be activated at all.

### Root cause

`profile_started()` reads `self.verbose` to gate its node-count logging, but
the attribute is never assigned. In `container_plugins/tempo/__init__.py`,
`self.verbose` appears exactly once - the read at line 307. The equivalent
functor in `container_plugins/tempoEx/__init__.py` does initialize it.

### Fix

Initialize `self.verbose` in the functor constructor from
`verbose_mode_container`, mirroring the TempoEx functor, and add the missing
`import gremlin.config`.

### Note

Unrelated, but in the same area: `container_plugins/tempoEx/__init__.py` sets
`self.verbose = True` on the line immediately after reading the config value,
which unconditionally forces verbose container logging for all users. That
looks like leftover debugging.