### PR TITLE
Make 'stop previous audio' interrupt playback instead of waiting for it

### DIFF
--- a/gremlin/sound.py
+++ b/gremlin/sound.py
@@ -1074,19 +1074,27 @@ class Sound:
             # terminate the thread pools
 
 
-            # Wait for active tasks to finish, but bound the wait so a stream
-            # that never completes (e.g. a stalled device) cannot hang the
-            # caller indefinitely. Previously this was an unbounded
-            # 'while self._sound_tasks' loop, which could freeze profile stop
-            # and 'stop previous audio' for minutes if a task got stuck.
-            deadline = time.time() + 2.0  # seconds
-            while True:
-                with self._tasks_lock:
-                    has_tasks = bool(self._sound_tasks)
-                if not has_tasks or time.time() >= deadline:
-                    break
-                self._task_trim()
-                time.sleep(0.01)
+            # Signal running streams to stop, then wait briefly for them to
+            # notice. The playback callback checks _is_playback_enabled() on
+            # every buffer, so disabling playback makes an active stream end at
+            # its next callback (a few milliseconds) instead of playing to
+            # completion. Without this signal the loop below simply waited for
+            # the current sound to finish, which made 'stop previous audio' do
+            # the opposite of what it promises and serialised the sound queue:
+            # each queued sound had to wait out the whole previous one.
+            self.pushPlaybackEnabled()
+            try:
+                deadline = time.time() + 0.5  # seconds - streams stop quickly once signalled
+                while True:
+                    with self._tasks_lock:
+                        has_tasks = bool(self._sound_tasks)
+                    if not has_tasks or time.time() >= deadline:
+                        break
+                    self._task_trim()
+                    time.sleep(0.005)
+            finally:
+                # re-enable playback so the caller can start the new sound
+                self.popPlaybackEnabled()
             with self._tasks_lock:
                 pending_tasks = list(self._sound_tasks)
             if pending_tasks:


### PR DESCRIPTION
### Problem

With several sound/TTS actions triggered in quick succession, announcements lag
badly behind the inputs that caused them. The sound event queue drains at a
fixed rate of roughly one sound per sound-duration, so a burst of triggers
plays back long after the fact.

From a session log (verbose sound logging), the queue drains in lockstep with
playback duration:

11:37:36.501 SOUNDLISTEN: DEQUEUE event Play QUEUE size: 3 11:37:38.363 SOUNDLISTEN: DEQUEUE event Play QUEUE size: 2 11:37:40.228 SOUNDLISTEN: DEQUEUE event Play QUEUE size: 1 11:37:40.272 SOUNDLISTEN: DEQUEUE event Play QUEUE size: 0


~1.87s between dequeues, which is the length of one announcement.

### Root cause

In the sound listener loop, `stop_previous` calls `soundStop()` before starting
the new sound. `soundStop()` waits for active tasks to disappear:

```python
deadline = time.time() + 2.0
while True:
    with self._tasks_lock:
        has_tasks = bool(self._sound_tasks)
    if not has_tasks or time.time() >= deadline:
        break
    self._task_trim()
    time.sleep(0.01)
```

Nothing tells the running stream to stop, so the loop just waits for the
current sound to play to completion (or hits the 2s cap). Because this runs on
the queue-processing thread, every queued sound has to wait out the previous
one. The option does the opposite of what it promises and serialises the queue.

Note this affects profiles that set `blocking="False"` on every action - the
serialisation comes from `soundStop()`, not from blocking playback.

### Fix

Signal the running streams before waiting. The playback callback in
`_play_runner` already checks `_is_playback_enabled()` on every buffer, so
disabling playback ends an active stream at its next callback rather than at
the end of the sample. `soundStop()` now wraps its wait in
`pushPlaybackEnabled()` / `popPlaybackEnabled()` and drops the cap to 0.5s,
since streams stop within a few milliseconds once signalled.

`_playback_enabled_stack` is a counter, so this nests correctly with the
existing push/pop in `_update_devices()`.

### Testing

Before: queue drains at one sound per ~1.9s, announcements lag behind input.
After: queue stays at zero, each new sound interrupts the previous one, which
is the documented behaviour of the option.