### PR TITLE
Guard against None event in tempo/tempoEx trigger handlers

### DIFF
--- a/container_plugins/tempo/__init__.py
+++ b/container_plugins/tempo/__init__.py
@@ -320,6 +320,11 @@ class TempoContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
     def _trigger_short_press(self, event, value, extra_data: dict = None):
         """triggers a short press"""
 
+        if event is None:
+            # can happen if a queued timer/thread callback fires after a mode
+            # change already cleared the pending event reference
+            return
+
         # syslog.info(f"execute short press {self.short_index}")
         ec = gremlin.execution_graph.ExecutionContext()
         if self.short_enabled:
@@ -330,6 +335,12 @@ class TempoContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
 
     def _trigger_long_press(self, event, value, extra_data: dict = None):
         """triggers a long press"""
+
+        if event is None:
+            # can happen if a queued timer/thread callback fires after a mode
+            # change already cleared the pending event reference
+            return
+
         # syslog.info(f"execute long press {self.long_index}")
         ec = gremlin.execution_graph.ExecutionContext()
         if self.long_enabled:

--- a/container_plugins/tempoEx/__init__.py
+++ b/container_plugins/tempoEx/__init__.py
@@ -731,6 +731,11 @@ class TempoExContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
     def _trigger_double_press(self, event, value, extra_data: dict = None):
         """called on double tap trigger"""
 
+        if event is None:
+            # can happen if a queued timer/thread callback fires after a mode
+            # change already cleared the pending event reference
+            return
+
         is_pressed = event.is_pressed
 
 
@@ -765,6 +770,11 @@ class TempoExContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
     def _trigger_short_press(self, event, value, extra_data: dict = None):
         """triggers a short press"""
 
+        if event is None:
+            # can happen if a queued timer/thread callback fires after a mode
+            # change already cleared the pending event reference
+            return
+
         is_pressed = event.is_pressed
         if is_pressed:
             if self.last_trigger:
@@ -797,6 +807,11 @@ class TempoExContainerFunctor(gremlin.base_profile.AbstractTriggerFunctor):
 
     def _trigger_long_press(self, event, value, extra_data: dict = None):
         """triggers a long press"""
+
+        if event is None:
+            # can happen if a queued timer/thread callback fires after a mode
+            # change already cleared the pending event reference
+            return
 
         is_pressed = event.is_pressed
 


### PR DESCRIPTION
### Problem

Changing runtime mode while a Tempo or TempoEx container has a press pending
can crash on `AttributeError: 'NoneType' object has no attribute 'is_pressed'`.

### Root cause

The short/long/double press handlers are invoked from `threading.Timer`
callbacks. A runtime mode change clears the pending event reference, but a
timer already scheduled still fires afterwards and reaches the handler with
`event` set to `None`. The handlers dereference `event` immediately.

### Fix

Return early when `event` is `None` in the five affected handlers:

- `container_plugins/tempo/__init__.py`: `_trigger_short_press`,
  `_trigger_long_press`
- `container_plugins/tempoEx/__init__.py`: `_trigger_short_press`,
  `_trigger_long_press`, `_trigger_double_press`

There is nothing meaningful to execute for a press whose mode is already gone,
so dropping the stale callback is the correct behaviour.