### PR TITLE
Fix gated-axis vJoy lag on high-rate sticks

### DIFF
--- a/gremlin/base_classes.py
+++ b/gremlin/base_classes.py
@@ -2166,6 +2166,28 @@ class FastQueue(Generic[T]):
 
         return True
 
+    def put_coalesce(self, item: T, key_fn, block: bool = True, timeout: float | None = None) -> bool:
+        """Replace the queued item with the same key, otherwise append.
+
+        Axis HID can outrun mapping. Keeping one pending sample per axis
+        avoids replaying a second of stick history into vJoy.
+        """
+        key = key_fn(item) if key_fn is not None else None
+        with self._condition:
+            self._wait_for_space(block, timeout)
+            if key is not None:
+                for index, existing in enumerate(self._queue):
+                    try:
+                        if key_fn(existing) == key:
+                            self._queue[index] = item
+                            self._condition.notify()
+                            return True
+                    except Exception:
+                        continue
+            self._queue.append(item)
+            self._condition.notify()
+        return True
+
     def putleft(self, item: T, block: bool = True, timeout: float | None = None) -> bool:
         """Add an item to the front of the queue."""
 

--- a/gremlin/event_handler.py
+++ b/gremlin/event_handler.py
@@ -501,6 +501,29 @@ class VjoyEvent:
         return f"VjoyEvent: vjoy [{self.vjoy_id}] type: [{self.input_type.name}] input: [{self.input_id}] value: [{value_stub}]"
 
 
+def _axis_event_key(event) -> tuple | None:
+    """Identity for coalescing pending axis samples. Buttons/hats stay queued in order."""
+    if event is None or not getattr(event, "is_axis", False):
+        return None
+    return (str(getattr(event, "device_guid", "")), getattr(event, "identifier", None))
+
+
+def _coalesce_axis_batch(event_list: list) -> list:
+    """Keep the latest sample per axis, preserve first-seen order among other events."""
+    if not event_list:
+        return event_list
+    latest = {}
+    slots = []
+    for event in event_list:
+        key = _axis_event_key(event)
+        if key is None:
+            slots.append(("keep", event))
+            continue
+        if key not in latest:
+            slots.append(("axis", key))
+        latest[key] = event
+    return [latest[item] if kind == "axis" else item for kind, item in slots]
+
 
 @gremlin.singleton_decorator.SingletonDecorator
 class EventListener(QtCore.QObject):
@@ -932,11 +955,18 @@ class EventListener(QtCore.QObject):
         if event.device_guid in self._valid_device_map:
             if self._verbose_queue:
                 syslog.info(f"EVENTLISTEN: QUEUE event {event.id}")
-            self._event_queue.put(event)
+            self._enqueue_joystick_event(event)
 
     def queueJoystickEventList(self, event_list):
         """queues a list of joystick events"""
         for event in event_list:
+            self._enqueue_joystick_event(event)
+
+    def _enqueue_joystick_event(self, event):
+        """Keep one pending sample per axis so mapping is not a delayed replay."""
+        if getattr(event, "is_axis", False):
+            self._event_queue.put_coalesce(event, _axis_event_key)
+        else:
             self._event_queue.put(event)
 
     # @ignore_function
@@ -956,6 +986,7 @@ class EventListener(QtCore.QObject):
             if not event_list:
                 time.sleep(0)
                 continue
+            event_list = _coalesce_axis_batch(event_list)
             for event in event_list:
                 joystick_event_emit(event)
                 joystick_event_ui_emit(event)

--- a/gremlin/gated_handler.py
+++ b/gremlin/gated_handler.py
@@ -1708,7 +1708,7 @@ class GateData:
                 # ignore if a different input axis on the input device
                 return False
 
-        # process curved intput
+        # process curved input
         if not event.is_virtual:
             input_value = gremlin.joystick_handling.get_curved_axis(
                 self._action_data.hardware_device_guid,
@@ -1716,6 +1716,14 @@ class GateData:
             )
         else:
             input_value = event.raw_value
+
+        if input_value is None:
+            input_value = event.value
+        else:
+            # Nested Map to vJoy prefers event.curve_value over the gated action
+            # value. Keep the event on live HID so analog output is not a replay.
+            event.value = input_value
+            event.curve_value = input_value
 
         # run mode - execute the functors with the gate data
 
@@ -1736,7 +1744,7 @@ class GateData:
             gh.fireValueChangedCallbacks(self._device_id, self._input_id, input_value)
 
         if triggers:
-            value = gremlin.actions.Value(event.value)
+            value = gremlin.actions.Value(input_value)
 
             range_event = event.clone()
             range_event.event_type = InputType.JoystickAxis  # force linear


### PR DESCRIPTION
## Summary
- High-rate HID axis packets were queued sample-by-sample, so Gated Axis replayed up to about a second of stick history into vJoy after the physical stick had already centered.
- Keep one pending sample per axis in the event queue (buttons and hats are unchanged).
- Drive nested Map to vJoy from live HID so gated analog output matches merge-style mappings instead of the queued packet.

## Test plan
- [ ] Profile with Gated Axis on a high-rate stick (e.g. Virpil) mapped to vJoy, plus a merge/simple remap on another stick.
- [ ] Start the profile, slam the gated stick, release to center, and move the other stick at the same time.
- [ ] Confirm the gated vJoy axis stays with the physical stick instead of catching up ~1s later.
- [ ] Confirm gate crossings / range enter-exit still fire when moving through gates quickly.
- [ ] Confirm buttons and hats still process in order.

Made with [Cursor](https://cursor.com)