### PR TITLE
Add Overlay tab for OBS chromakey and on-screen HUD

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,8 @@ OSC (Open Sound Control) is a very important feature support in GremlinEx that a
 
 For Elgato Stream Deck specifically, GremlinEx also supports a direct [Stream Deck plugin bridge](streamdeck.md) that keeps Stream Deck software running (no Companion required for those keys).
 
+Joystick axes and buttons can be drawn on a chromakey window for OBS, or as an on-screen HUD, without Touch OSC. See the [overlay](obs_overlay.md) guide.
+
 Please see the [OSC configuration section](usage.md#osc-device-open-sound-control) for OSC specific setup to enable this feature.  
 
 ### Virus False positives
@@ -146,6 +148,7 @@ GremlinEx is based on a fork from the 2019 [Joystick Gremlin by Whitemagic](http
 - Support for extended keys including F13 to F24 and media keys
 - Selectable voice and playback speed for text to speech prompts
 - Modern user interface with dark UI theme support
+- [Overlay designer](obs_overlay.md) for chromakey or on-screen joystick visualization without Touch OSC
 
 While GremlinEx is based on Joystick Gremlin, it's important to note they are not the same software, certainly not internally, but also from the standpoint of behaviors.  GremlinEx is heavily event based, has a completely different execution engine.  While legacy profiles may load in GremlinEx, complete compatibility is not assured.
 

--- a/docs/obs_overlay.md
+++ b/docs/obs_overlay.md
@@ -1,0 +1,108 @@
+# Overlay
+
+The Overlay tab draws live physical, vJoy, and GEX state inputs on either a chromakey (or image) window for OBS, or a transparent on-screen HUD. It replaces a Touch OSC + OSC round-trip when you only need a joystick overlay.
+
+## Enable it on a profile
+
+Open the **Overlay** tab (next to Settings and Plugins). Each GEX profile has its own overlay; switching profiles loads that profile’s layout. The tab title shows the active profile name.
+
+Layouts are stored in the profile’s companion JSON (`<profile>.json`, key `obs_overlay`). An optional `<profile>.overlay.json` sidecar is also written so you can import/export layouts. Saving the GEX profile saves the overlay with it.
+
+A user plugin is **not** required. [`user_plugins/obs_overlay.py`](../user_plugins/obs_overlay.py) only adds a Plugins-tab button that jumps to Overlay.
+
+## Pages
+
+The Overlay tab can hold several independent **pages** (sub-tabs under the toolbar). Each page has its own widgets, background, Interactive flag, and live window.
+
+- **Add** with the **+** button. **Rename** by double-clicking a tab (or Canvas → **Name**). Right-click a tab to **Duplicate** or **Delete** (at least one page remains).
+- **Show overlay** and **Interactive** on the toolbar apply only to the **selected** page. Other pages keep their own windows and Interactive setting. **Hide overlay** closes that page’s window.
+- **Visible** (Canvas, when nothing is selected) closes this page’s live window when unchecked. Per-page **Toggle overlay** and **Show at profile start** can still open other pages.
+- Designer edits one page at a time (the active tab). Widgets do not drag between tabs; Duplicate page copies the layout.
+- Older layouts load as a single tab named **Overlay**.
+
+## Background modes
+
+### Chroma / image (OBS)
+
+1. Set **Background** to **chroma** or **image**.
+2. Click **Show overlay**. That opens the selected page’s window, titled `GEX Overlay — {page name}` (for example `GEX Overlay — HUD`). Switch tabs and click Show overlay again to open another page.
+3. In OBS, add a **Window Capture** source for that title.
+4. For chroma, add a **Chroma Key** filter. The default key color is `#00FF00`. Set the color’s **alpha to 0** if you want the overlay itself to be transparent so the desktop shows through. That live window is frameless (use the drag bar to move it). The designer canvas shows a checkerboard. OBS window capture still needs an opaque chroma color.
+5. Hide the overlay drag bar (right-click the overlay, or uncheck **Overlay drag bar**) before going live.
+
+A background **image** can be used instead of chroma if you want a static HUD plate.
+
+Chroma/image windows remember their **screen position**. **Reset position** (Canvas) clears the saved coordinates and recenters the window. The same reset runs automatically if the saved monitor is gone. On-screen pages cover a chosen monitor instead; Reset position falls back to the primary display.
+
+### On-screen HUD
+
+1. Set **Background** to **on-screen**.
+2. Pick the **Monitor**. The canvas width and height update to that monitor’s resolution.
+3. Click **Show overlay** (or enable **Show at profile start**). The overlay covers that monitor and stays on top. With **Interactive** off it is click-through so games keep mouse and keyboard focus. With **Interactive** on it captures touch on that screen.
+
+Use **Hide overlay** on the Overlay tab to close the selected page’s on-screen HUD.
+
+## Interactive (touch → vJoy / states)
+
+Check **Interactive** on the Overlay toolbar (or Canvas when nothing is selected). It applies to the selected page only. Touch or click a widget on that page’s live overlay window — not the designer canvas, and not an OBS preview. Physical device bindings stay display-only.
+
+- **vJoy button:** held while pressed, released on lift.
+- **State button:** tap inverts the state.
+- **Sticks / radar / circular / hat:** drag; lift returns to center.
+- **Bar / fader / radio / radial / encoder:** drag; lift keeps the value.
+- Multi-touch is supported (one finger per widget). Empty space is click-through so the desktop or game keeps the mouse.
+
+vJoy writes go straight to that device; the profile does not have to be running. Hide overlay to release any held vJoy buttons.
+
+## Profile start
+
+Check **Show at profile start** on a page (Canvas). Activating the profile opens that page automatically if **Visible** is also on, and hides live windows when the profile stops.
+
+**Toggle overlay** (Canvas) is per page: assign a physical, vJoy, or GEX state input the same way widget bindings do (pick a device or click **Listen...**). While the profile is running, a press shows or hides **that page’s** window, not every overlay page. This works whether or not Show at profile start is on.
+
+## Designer
+
+- **Palette:** click to add a widget at the center of the current canvas view. If a widget is already selected, the click changes it to this type and keeps compatible settings (geometry, colors, fonts, and bindings when they still apply).
+- **Templates:** dual-stick HUD, Xbox-style gamepad, throttle pair. **Save template** stores the current widgets globally under the GEX data folder (`overlay_templates/`), not in the profile. An empty canvas is the default for a new profile. Built-in templates are click-to-apply only. Right-click a **saved** template to overwrite it with the current widgets and properties, or to delete it.
+- Drag, resize, snap-to-grid, Shift+click multi-select. Hold **Shift** while resizing to keep the aspect ratio (widgets and groups). Right-click selected widgets to duplicate, delete, bring forward, send backward, group, or ungroup. A grouped (or multi-selected) set resizes together from the dashed bounding-box handles. Delete, Ctrl+D, Ctrl+G / Ctrl+Shift+G, Ctrl+Z, and arrow-key nudge still work. Widgets that sit outside a smaller canvas (after a resize or leaving on-screen mode) stay visible in the dark overflow area and can be dragged back; the live overlay still only shows what is on the canvas.
+- Inspector **Geometry** includes **Scale font with size**. Appearance puts **Opacity** (percent slider) above fill color, then widget-specific fill/dot controls. **Grid**, **Crosshairs**, **Axis** (N/S/E/W labels, distance, font), and **Border** (color, width, corner radius) are separate groups. Grids reach the widget border; **Fade at border** tapers them toward the edge.
+- **Shape** replaces Panel: rectangle, circle, triangle, diamond, line, or freeform. Freeform points are added by double-clicking the outline; drag a point, then drag its yellow handles to Bézier-curve that corner. Uncheck **Closed** for an open path.
+- **Image** is a separate palette widget. Browse to a PNG, WebP, GIF, JPEG, or BMP. Formats with an alpha channel keep their transparency; Fill is only a backdrop behind those pixels. **Keep aspect ratio** (on by default) fits the picture in the widget instead of stretching it.
+- **Stream Deck** mirrors a connected Elgato deck: pick the device (or First connected), optionally follow the hardware GEX page, and the overlay draws that deck’s keys with the same art as the Stream Deck designer. Stream Deck + also shows the LCD row and dials. **Fit to device** sizes the widget to that layout. This widget has no joystick binding.
+- Inspector: size, colors, fonts, line/dot sizes, labels (including fill and border), invert, deadzone, and binding. Selecting a **group** (or multiple widgets) shows only shared properties; edits apply to every selected widget. With **Scale font with size** on, Font size shows the size currently drawn and updates while you resize the widget.
+- **Guides** (Canvas): add vertical and/or horizontal lines, set a color, drag them on the canvas, or type a percent of width/height. Moving or resizing a widget snaps its left/right/center (or top/bottom/center) to nearby guides.
+- **Color palettes** sit at the top of Appearance as two rows: built-in defaults (click to apply) and user palettes. They are per widget type and stored globally (`overlay_color_palettes.json` in the GEX data folder), not in the profile. **+** saves the current colors as a user square. Right-click a user square to overwrite it or delete it. Default palettes cannot be changed. Transparent fills show as a square with a cross. Built-in squares: default, Touch OSC (red), transparent green.
+
+Widget mapping (Touch OSC-style names in the palette):
+
+| Palette | What it is |
+|---|---|
+| Bar | 1D pad with a moving dot (horizontal or vertical), same language as the X/Y square; N/S labels when vertical, E/W when horizontal |
+| Radio | Stepped cells along one axis |
+| Fader | Ladder track, fill below the thumb, and a sliding thumb |
+| Radial | 270° arc with ticks |
+| Encoder | Full donut with ticks and one moving highlighted wedge |
+| X/Y | 2D square pad; optional lines through the dot, circle/square dot, shadow |
+| Radar | Concentric rings, a beam from the center, and a circle through the current position; optional 15/30/45° angle lines |
+| Circular | Round 2D pad; optional angle lines |
+| Shape | Rectangle, circle, triangle, diamond, line, or freeform Bézier path |
+| Image | Custom picture; PNG/WebP/GIF keep transparency |
+| Stream Deck | Live preview of a connected Elgato Stream Deck |
+
+## Bindings
+
+Each widget (except labels, shapes, images, and Stream Deck widgets) can bind to:
+
+- a **physical** device axis, button, or hat (use **Listen...** or pick from the lists)
+- a **vJoy** axis, button, or hat
+- a named GEX **state**
+
+2D sticks and the radar widget have **two independent bindings** (Axis X and Axis Y). Each axis has its own device and axis picker (or Listen). You can mix devices — for example physical X on a stick and vJoy Y on another device.
+
+## Notes
+
+- For OBS, capture **GEX Overlay — {page name}**, not the Overlay tab. Each page is a separate window.
+- Layouts are per profile. Saving the layout or the GEX profile writes the overlay into that profile’s config (and a sidecar JSON). **Load layout...** imports a JSON file into the current profile.
+- Axis labels (N/S/E/W) have their own font, size, weight, color, and **Distance from center** slider in the inspector (100 = near the border with even padding; 0 = stacked at the center). 2D sticks and hats use all four; bars show North/South when vertical and East/West when horizontal.
+- **Deadzone display** is overlay-only. Axis values inside that range around center are drawn as zero; it does not change GEX mappings.
+- Photoreal HOTAS meshes, DJ decks, and an OBS Browser Source path are not in this version.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -70,7 +70,9 @@ It is generally recommended to use GremlinEx to map to default settings in a gam
 
 ### Input and output from/to glass surface panels (touchscreens)
 
-GremlinEx map input from/to glass surfaces (touch screens) and hardware panels like Streamdeck using the OSC protocol using open source software.  Using OSC open source software like Open Stage Control, you can design custom glass surface input screens and map them over the network to GremlinEx.   GremlinEx supports both message triggers, and axis including multi-axis data inboud from a glass surface, such as a slider or an XY pad.  
+GremlinEx map input from/to glass surfaces (touch screens) and hardware panels like Streamdeck using the OSC protocol using open source software.  Using OSC open source software like Open Stage Control, you can design custom glass surface input screens and map them over the network to GremlinEx.   GremlinEx supports both message triggers, and axis including multi-axis data inboud from a glass surface, such as a slider or an XY pad.
+
+For a joystick visualization overlay in OBS (chromakey window capture) or as an on-screen HUD, see the [overlay designer](obs_overlay.md).  
 
 #### Networked devices support
 

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -33,6 +33,8 @@ Plugins will also need to handle external dependencies that are not part of the 
 
 Is is recommended to stay away from UI elements in a user plugin but it is completely possible to leverage the QT library inside a user plugin.  A user interface for a plugin is a very advanced feature and at this point, you are most likely considering a custom action or container plugin rather than a user plugin.  If this is the case, the source code for actions/containers should be examined as they require a very specific structure to be loaded and executed.
 
+`ButtonVariable` (plugin variable type Action) can add a launch button to the Plugins tab configuration panel. The shipped [overlay](obs_overlay.md) plugin uses this to switch to the Overlay tab.
+
 ## Load behavior
 
 A user plugin is loaded whenever a profile starts.  This will identify any exceptions/errors in the plugin when the profile starts.  

--- a/gremlin/base_profile.py
+++ b/gremlin/base_profile.py
@@ -3407,6 +3407,8 @@ class Profile:
             # plugins
             plugins = gremlin.shared_state.current_profile.plugins
             return len(plugins) > 0
+        elif device_guid == gremlin.shared_state.overlay_tab_guid:
+            return True
         elif device_guid == gremlin.shared_state.keyboard_tab_guid:
             look_for_containers = False
 
@@ -4783,7 +4785,7 @@ class Profile:
                 backup_file = os.path.join(backup_path, f"{base_name}.{backup_count}.xml")
                 try:
                     shutil.copyfile(use_name, backup_file)
-                    ext_list = ["json", ".calib"]
+                    ext_list = ["json", ".calib", "overlay.json"]
                     for ext in ext_list:
                         json_source = gremlin.util.swap_ext(use_name, ext)
                         json_target = gremlin.util.swap_ext(backup_file, ext)
@@ -4804,6 +4806,12 @@ class Profile:
                 self.to_xml(use_name)
                 if verbose:
                     syslog.info(f"SAVE: [{gremlin.util.toUrl(self._profile_fname)}]")
+                try:
+                    import gremlin.ui.obs_overlay as obs_overlay
+
+                    obs_overlay.persist_for_profile(self)
+                except Exception:
+                    pass
 
             except Exception as err:
                 syslog.error(f"SAVE: error: [{gremlin.util.toUrl(self._profile_fname)}]")
@@ -6042,6 +6050,8 @@ class PluginVariable:
         """true if the variable is configured"""
         if self.type is None or self.name is None:
             return False
+        if self.type == PluginVariableType.Action:
+            return True
         if self.type == PluginVariableType.PhysicalInput:
             if self.value and "device_id" in self.value:
                 return self.value["device_id"] is not None
@@ -6106,9 +6116,14 @@ class PluginVariable:
                     "input_id": safe_read(node, "input-id", int, 1),
                     "input_type": InputType.to_enum(safe_read(node, "input-type", str, "")),
                 }
+        elif self.type == PluginVariableType.Action:
+            self.value = None
 
     def to_xml(self):
         """read user plugin saved variable data"""
+
+        if self.type == PluginVariableType.Action:
+            return None
 
         node = etree.Element("variable")
         node.set("name", safe_format(self.name, str))

--- a/gremlin/config.py
+++ b/gremlin/config.py
@@ -2210,7 +2210,7 @@ class Configuration(QtCore.QObject):
             case DeviceType.ModeControl:
                 save_input_id = input_id
                 input_type = InputType.ModeControl
-            case DeviceType.Settings:
+            case DeviceType.Settings | DeviceType.Plugins | DeviceType.Overlay:
                 input_type = InputType.NotSet
                 input_id = None
                 save_input_id = None

--- a/gremlin/joystick_handling.py
+++ b/gremlin/joystick_handling.py
@@ -1265,6 +1265,14 @@ def registerSpecialDevices():
     device.device_category = DeviceCategory.Config
     registerConfigDevice(device)
 
+    # overlay designer
+    device = DeviceSummary()
+    device.name = "Overlay"
+    device.device_guid = gremlin.shared_state.overlay_tab_guid
+    device.device_type = DeviceType.Overlay
+    device.device_category = DeviceCategory.Config
+    registerConfigDevice(device)
+
 
 def getSpecialDevices() -> list:
     """gets all special devices"""

--- a/gremlin/shared_state.py
+++ b/gremlin/shared_state.py
@@ -123,6 +123,10 @@ plugins_tab_id = gremlin.util.normalize_guid(plugins_tab_guid)
 settings_tab_guid = gremlin.util.parse_guid('5b70b5ba-bded-41a8-bd91-d8a209b8e981')
 settings_tab_id = gremlin.util.normalize_guid(settings_tab_guid)
 
+# UUID of the overlay designer tab (OBS / on-screen overlay)
+overlay_tab_guid = gremlin.util.parse_guid('c8f3a91e-2d47-4b6c-9e15-7a6d4c2b8f01')
+overlay_tab_id = gremlin.util.normalize_guid(overlay_tab_guid)
+
 # UUID of the MIDI tab (midi device)
 midi_tab_guid = gremlin.util.parse_guid('1b56ecf7-0624-4049-b7b3-8d9b7d8ed7e0')
 midi_tab_id = gremlin.util.normalize_guid(midi_tab_guid)
@@ -187,6 +191,7 @@ def isDeviceTabActive(device_guid):
 virtual_device_guid_type_map = [
     (plugins_tab_guid, DeviceType.NotSet),
     (settings_tab_guid, DeviceType.Settings),
+    (overlay_tab_guid, DeviceType.Overlay),
     (midi_tab_guid, DeviceType.Midi),
     (osc_tab_guid, DeviceType.Osc),
     (mode_tab_guid, DeviceType.ModeControl),
@@ -206,6 +211,7 @@ def _init_special_device_guids():
     _virtual_device_guid_to_name_map[str(midi_tab_guid).casefold()] = "MIDI"
     _virtual_device_guid_to_name_map[str(settings_tab_guid).casefold()] = "Settings"
     _virtual_device_guid_to_name_map[str(plugins_tab_guid).casefold()] = "Plugins"
+    _virtual_device_guid_to_name_map[str(overlay_tab_guid).casefold()] = "Overlay"
     _virtual_device_guid_to_name_map[str(mode_tab_guid).casefold()] = "Modes"
     _virtual_device_guid_to_name_map[str(streamdeck_tab_guid).casefold()] = "Stream Deck (legacy)"
 

--- a/gremlin/types.py
+++ b/gremlin/types.py
@@ -288,6 +288,7 @@ class DeviceType(IntEnum):
     Maestro = 11  # maestro special device
     StreamDeck = 12  # Elgato Stream Deck via plugin bridge
     Voice = 13  # voice special device
+    Overlay = 14  # OBS / on-screen overlay designer tab
 
     @staticmethod
     def isFixedInput(value: DeviceType) -> bool:
@@ -305,6 +306,7 @@ class DeviceType(IntEnum):
             DeviceType.NotSet,
             DeviceType.Settings,
             DeviceType.Plugins,
+            DeviceType.Overlay,
         )
 
     @staticmethod
@@ -349,6 +351,7 @@ _DeviceType_to_display_name = {
     DeviceType.Maestro: "Maestro",
     DeviceType.StreamDeck: "Stream Deck",
     DeviceType.Voice: "Voice",
+    DeviceType.Overlay: "Overlay",
 }
 
 _DeviceType_to_string_lookup = {
@@ -366,6 +369,7 @@ _DeviceType_to_string_lookup = {
     DeviceType.Maestro: "maestro",
     DeviceType.StreamDeck: "streamdeck",
     DeviceType.Voice: "voice",
+    DeviceType.Overlay: "overlay",
 }
 
 
@@ -384,6 +388,7 @@ _DeviceType_to_enum_lookup = {
     "maestro": DeviceType.Maestro,
     "streamdeck": DeviceType.StreamDeck,
     "voice": DeviceType.Voice,
+    "overlay": DeviceType.Overlay,
 }
 
 
@@ -398,6 +403,7 @@ class PluginVariableType(xIntEnum):
     VirtualInput = 6
     Mode = 7
     Selection = 8
+    Action = 9
 
     @staticmethod
     def to_string(value: PluginVariableType) -> str:  # noqa: F821
@@ -425,6 +431,7 @@ _PluginVariableType_to_string_lookup = {
     PluginVariableType.VirtualInput: "VirtualInput",
     PluginVariableType.Mode: "Mode",
     PluginVariableType.Selection: "Selection",
+    PluginVariableType.Action: "Action",
 }
 _PluginVariableType_to_enum_lookup = {
     "Int": PluginVariableType.Int,
@@ -435,6 +442,7 @@ _PluginVariableType_to_enum_lookup = {
     "VirtualInput": PluginVariableType.VirtualInput,
     "Mode": PluginVariableType.Mode,
     "Selection": PluginVariableType.Selection,
+    "Action": PluginVariableType.Action,
 }
 
 
@@ -1117,6 +1125,7 @@ class TabDeviceType(int, Enum):
     MaestroOutput = 13
     StreamDeck = 14
     Voice = 15
+    Overlay = 16
 
 
 class GamePadOutput(Enum):

--- a/gremlin/ui/dialogs.py
+++ b/gremlin/ui/dialogs.py
@@ -4788,7 +4788,7 @@ class DeviceDisplayDialog(gremlin.ui.ui_common.QRememberDialog):
             item.setData(QtCore.Qt.UserRole, (device, visible))
             item.setSizeHint(widget.sizeHint())
             widget.setListWidget(item)
-            enabled = device.device_type not in (DeviceType.Plugins, DeviceType.Settings)
+            enabled = device.device_type not in (DeviceType.Plugins, DeviceType.Settings, DeviceType.Overlay)
             widget.setVisibleEnabled(enabled)
             self._list_widget.setItemWidget(item, widget)
 

--- a/gremlin/ui/input_viewer.py
+++ b/gremlin/ui/input_viewer.py
@@ -725,7 +725,7 @@ class VisualizerWidget(QtWidgets.QWidget):
 
                         count = self._device.button_count
                         bw = 38 + 8  # width + margin of 4
-                        cols = w // bw
+                        cols = max(1, w // bw)
                         rows = (count + cols - 1) // cols
                         h = rows * bw
 

--- a/gremlin/ui/obs_overlay/__init__.py
+++ b/gremlin/ui/obs_overlay/__init__.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""OBS chromakey overlay designer and capture window."""
+
+from __future__ import annotations
+
+import logging
+
+from PySide6 import QtCore
+from psygnal import Signal
+from shiboken6 import Shiboken
+
+import gremlin.event_handler
+import gremlin.shared_state
+import gremlin.util
+from gremlin.singleton_decorator import SingletonDecorator
+
+from .bindings import read_toggle_active
+from .designer import OverlayDesignerWidget
+from .model import OverlayScene, is_onscreen_mode, normalize_background_mode
+from .overlay_window import OverlayWindow, apply_onscreen_geometry
+from .widgets import live_window_is_layered
+
+syslog = logging.getLogger("system")
+
+
+@SingletonDecorator
+class OverlayManager:
+    """Owns the shared scene, designer, and overlay windows (one per visible page)."""
+
+    visibility_changed = Signal()
+
+    def __init__(self):
+        self.scene = OverlayScene()
+        self._overlays: dict[str, OverlayWindow] = {}
+        self._hooks = False
+        self._auto_shown = False
+        self._page_chrome: dict[str, tuple] = {}
+        self._page_visible_flags: dict[str, bool] = {}
+        self._toggle_timer = None
+        self._toggle_active: dict[str, bool] = {}
+        self._recreate_pending: set[str] = set()
+        self._bind_profile_hooks()
+        self.scene.load_for_profile()
+        self._apply_all_onscreen()
+        self._refresh_page_chrome()
+        self.scene.changed.connect(self._on_scene_changed)
+
+    def _bind_profile_hooks(self):
+        if self._hooks:
+            return
+        el = gremlin.event_handler.EventListener()
+        el.profile_loaded.connect(self._on_profile_loaded)
+        el.profile_unloaded.connect(self._on_profile_unloaded)
+        el.profile_started.connect(self._on_profile_started)
+        el.profile_stop.connect(self._on_profile_stop)
+        el.tabs_loaded.connect(self._on_tabs_loaded)
+        self._hooks = True
+
+    def _apply_all_onscreen(self):
+        for page in self.scene.pages:
+            apply_onscreen_geometry(self.scene, emit=False, page_id=page["id"])
+
+    def _page_chrome_tuple(self, page_id: str) -> tuple:
+        canvas = self.scene.canvas_for(page_id)
+        return (
+            normalize_background_mode(canvas.get("background_mode")),
+            live_window_is_layered(canvas),
+        )
+
+    def _refresh_page_chrome(self):
+        self._page_chrome = {page["id"]: self._page_chrome_tuple(page["id"]) for page in self.scene.pages}
+        self._page_visible_flags = {page["id"]: bool(page.get("visible", True)) for page in self.scene.pages}
+
+    def _load_current_profile_scene(self):
+        self.scene.load_for_profile()
+        self._apply_all_onscreen()
+        self._refresh_page_chrome()
+
+    def _on_profile_loaded(self):
+        if self.scene.dirty:
+            self.scene.save_owned()
+        self._load_current_profile_scene()
+
+    def _on_profile_unloaded(self):
+        if self.scene.dirty:
+            self.scene.save_owned()
+        gremlin.util.InvokeUiMethod(self._stop_runtime_toggle)
+        self.hide_overlay()
+        # New Profile never emits profile_loaded; drop the previous layout now
+        # so the designer does not keep showing it on the empty profile.
+        self._load_current_profile_scene()
+
+    def _on_tabs_loaded(self):
+        self._ensure_current_profile_scene()
+
+    def _on_profile_started(self):
+        gremlin.util.InvokeUiMethod(self._start_runtime_toggle)
+        auto_ids = [
+            page["id"]
+            for page in self.scene.pages
+            if page.get("visible", True) and page.get("canvas", {}).get("show_on_profile_start")
+        ]
+        if auto_ids:
+            self._auto_shown = True
+            QtCore.QTimer.singleShot(0, lambda ids=auto_ids: self.show_overlay(auto=True, page_ids=ids))
+
+    def _on_profile_stop(self):
+        gremlin.util.InvokeUiMethod(self._release_overlay_touch)
+        gremlin.util.InvokeUiMethod(self._stop_runtime_toggle)
+        auto = self._auto_shown or any(
+            page.get("canvas", {}).get("show_on_profile_start") for page in self.scene.pages
+        )
+        if auto:
+            self._auto_shown = False
+            self.hide_overlay()
+
+    def _start_runtime_toggle(self):
+        self._toggle_active = {
+            page["id"]: read_toggle_active(page.get("canvas", {}).get("toggle_binding"))
+            for page in self.scene.pages
+        }
+        if self._toggle_timer is None:
+            timer = QtCore.QTimer()
+            timer.setTimerType(QtCore.Qt.TimerType.PreciseTimer)
+            timer.setInterval(16)
+            timer.timeout.connect(self._poll_toggle)
+            self._toggle_timer = timer
+        if not self._toggle_timer.isActive():
+            self._toggle_timer.start()
+
+    def _stop_runtime_toggle(self):
+        if self._toggle_timer is not None:
+            self._toggle_timer.stop()
+        self._toggle_active = {}
+
+    def _poll_toggle(self):
+        for page in self.scene.pages:
+            page_id = page["id"]
+            binding = page.get("canvas", {}).get("toggle_binding")
+            active = read_toggle_active(binding)
+            rising = active and not self._toggle_active.get(page_id, False)
+            self._toggle_active[page_id] = active
+            if not rising:
+                continue
+            if self.page_is_visible(page_id):
+                self._auto_shown = False
+                self.hide_overlay_page(page_id)
+            else:
+                self._auto_shown = True
+                self.show_overlay(auto=True, page_ids=[page_id])
+
+    def _ensure_current_profile_scene(self):
+        if self.scene.belongs_to_profile():
+            return
+        if self.scene.dirty:
+            self.scene.save_owned()
+        self._load_current_profile_scene()
+
+    def _on_scene_changed(self):
+        live_ids = {page["id"] for page in self.scene.pages}
+        for page_id in list(self._overlays):
+            if page_id not in live_ids:
+                self._hide_page_ui(page_id)
+        recreate = []
+        for page in self.scene.pages:
+            page_id = page["id"]
+            chrome = self._page_chrome_tuple(page_id)
+            previous = self._page_chrome.get(page_id)
+            self._page_chrome[page_id] = chrome
+            if previous is not None and previous != chrome and self.page_is_visible(page_id):
+                recreate.append(page_id)
+            visible = bool(page.get("visible", True))
+            was_visible = self._page_visible_flags.get(page_id)
+            self._page_visible_flags[page_id] = visible
+            if was_visible is True and not visible:
+                self._hide_page_ui(page_id)
+        for page_id in recreate:
+            if page_id in self._recreate_pending:
+                continue
+            self._recreate_pending.add(page_id)
+            QtCore.QTimer.singleShot(0, lambda pid=page_id: gremlin.util.InvokeUiMethod(self._recreate_page_ui, pid))
+
+    def _recreate_page_ui(self, page_id: str):
+        self._recreate_pending.discard(page_id)
+        was_visible = self.page_is_visible(page_id)
+        self._hide_page_ui(page_id)
+        if was_visible:
+            self._show_page_ui(page_id)
+
+    def launch_designer(self, parent=None):
+        gremlin.util.InvokeUiMethod(self._launch_designer_ui, parent)
+
+    def _launch_designer_ui(self, parent=None):
+        self._ensure_current_profile_scene()
+        ui = gremlin.shared_state.ui
+        guid = gremlin.shared_state.overlay_tab_guid
+        if ui is not None:
+            ui.selectTabWidget(guid)
+            return
+        syslog.warning("OBS OVERLAY: main window is not ready; Overlay tab cannot be selected")
+
+    def overlay_is_visible(self) -> bool:
+        return any(self.page_is_visible(page_id) for page_id in list(self._overlays))
+
+    def page_is_visible(self, page_id: str) -> bool:
+        window = self._overlays.get(page_id)
+        return window is not None and Shiboken.isValid(window) and window.isVisible()
+
+    def show_overlay(self, auto: bool = False, page_ids: list[str] | None = None):
+        gremlin.util.InvokeUiMethod(self._show_overlay_ui, auto, page_ids)
+
+    def hide_overlay_page(self, page_id: str):
+        gremlin.util.InvokeUiMethod(self._hide_page_ui, page_id)
+
+    def _show_overlay_ui(self, auto: bool = False, page_ids: list[str] | None = None):
+        try:
+            self._ensure_current_profile_scene()
+            self._apply_all_onscreen()
+            if page_ids is None:
+                active = self.scene.active_page_id
+                targets = [active] if active and self.scene.page_by_id(active) else []
+            else:
+                targets = [page_id for page_id in page_ids if self.scene.page_by_id(page_id)]
+            for page_id in targets:
+                self._show_page_ui(page_id, auto=auto)
+            if auto and targets:
+                syslog.info("OBS OVERLAY: window opened for profile start")
+            self._emit_visibility()
+        except Exception as err:
+            syslog.error(f"OBS OVERLAY: failed to open overlay window: {err}")
+
+    def _show_page_ui(self, page_id: str, auto: bool = False):
+        apply_onscreen_geometry(self.scene, emit=False, page_id=page_id)
+        window = self._overlays.get(page_id)
+        if window is not None and Shiboken.isValid(window):
+            window._apply_window_flags()
+            window.show()
+            if not is_onscreen_mode(self.scene.canvas_for(page_id)):
+                window.raise_()
+            return
+        window = OverlayWindow(self.scene, page_id=page_id)
+        window.destroyed.connect(lambda *_args, pid=page_id: self._overlay_destroyed(pid))
+        self._overlays[page_id] = window
+        self._page_chrome[page_id] = self._page_chrome_tuple(page_id)
+        window.show()
+
+    def _overlay_destroyed(self, page_id: str):
+        current = self._overlays.get(page_id)
+        if current is None or not Shiboken.isValid(current):
+            self._overlays.pop(page_id, None)
+            self._emit_visibility()
+
+    def hide_overlay(self):
+        gremlin.util.InvokeUiMethod(self._hide_overlay_ui)
+
+    def _hide_overlay_ui(self):
+        for page_id in list(self._overlays):
+            self._hide_page_ui(page_id)
+        self._emit_visibility()
+
+    def _hide_page_ui(self, page_id: str):
+        window = self._overlays.pop(page_id, None)
+        if window is None:
+            return
+        try:
+            if Shiboken.isValid(window):
+                window.detach_from_scene()
+                window.hide()
+                window.close()
+                window.deleteLater()
+        except Exception as err:
+            syslog.warning(f"OBS OVERLAY: failed to close overlay window: {err}")
+        self._emit_visibility()
+
+    def _release_overlay_touch(self):
+        for window in list(self._overlays.values()):
+            if window is not None and Shiboken.isValid(window):
+                window.view.release_touch()
+
+    def _emit_visibility(self):
+        try:
+            self.visibility_changed.emit()
+        except Exception:
+            pass
+
+
+def launch_designer(parent=None):
+    OverlayManager().launch_designer(parent)
+
+
+def show_overlay(auto: bool = False):
+    OverlayManager().show_overlay(auto=auto)
+
+
+def hide_overlay():
+    OverlayManager().hide_overlay()
+
+
+def persist_for_profile(profile) -> bool:
+    """Write the in-memory overlay into the given profile if it owns the scene."""
+    try:
+        if OverlayManager.instance is None:
+            return False
+        scene = OverlayManager().scene
+        current = gremlin.shared_state.current_profile
+        if current is not profile:
+            return False
+        if scene._profile_key and not scene.belongs_to_profile(profile):
+            return False
+        return scene.save_to_profile(profile)
+    except Exception as err:
+        syslog.warning(f"OBS OVERLAY: persist on profile save failed: {err}")
+        return False
+
+
+def current_scene() -> OverlayScene:
+    return OverlayManager().scene

--- a/gremlin/ui/obs_overlay/__init__.py
+++ b/gremlin/ui/obs_overlay/__init__.py
@@ -85,24 +85,37 @@ class OverlayManager:
         self._refresh_page_chrome()
 
     def _on_profile_loaded(self):
+        # profile_loaded is a psygnal Signal and may fire on the profile-load
+        # worker thread — never touch Qt widgets / scene emits from there.
+        gremlin.util.InvokeUiMethod(self._on_profile_loaded_ui)
+
+    def _on_profile_loaded_ui(self):
         if self.scene.dirty:
             self.scene.save_owned()
         self._load_current_profile_scene()
 
     def _on_profile_unloaded(self):
+        # Same as loaded: unload runs on WorkManager; inspector rebuild must
+        # stay on the UI thread or GEX hangs (Not Responding).
+        gremlin.util.InvokeUiMethod(self._on_profile_unloaded_ui)
+
+    def _on_profile_unloaded_ui(self):
         if self.scene.dirty:
             self.scene.save_owned()
-        gremlin.util.InvokeUiMethod(self._stop_runtime_toggle)
+        self._stop_runtime_toggle()
         self.hide_overlay()
         # New Profile never emits profile_loaded; drop the previous layout now
         # so the designer does not keep showing it on the empty profile.
         self._load_current_profile_scene()
 
     def _on_tabs_loaded(self):
-        self._ensure_current_profile_scene()
+        gremlin.util.InvokeUiMethod(self._ensure_current_profile_scene)
 
     def _on_profile_started(self):
-        gremlin.util.InvokeUiMethod(self._start_runtime_toggle)
+        gremlin.util.InvokeUiMethod(self._on_profile_started_ui)
+
+    def _on_profile_started_ui(self):
+        self._start_runtime_toggle()
         auto_ids = [
             page["id"]
             for page in self.scene.pages
@@ -113,8 +126,11 @@ class OverlayManager:
             QtCore.QTimer.singleShot(0, lambda ids=auto_ids: self.show_overlay(auto=True, page_ids=ids))
 
     def _on_profile_stop(self):
-        gremlin.util.InvokeUiMethod(self._release_overlay_touch)
-        gremlin.util.InvokeUiMethod(self._stop_runtime_toggle)
+        gremlin.util.InvokeUiMethod(self._on_profile_stop_ui)
+
+    def _on_profile_stop_ui(self):
+        self._release_overlay_touch()
+        self._stop_runtime_toggle()
         auto = self._auto_shown or any(
             page.get("canvas", {}).get("show_on_profile_start") for page in self.scene.pages
         )

--- a/gremlin/ui/obs_overlay/bindings.py
+++ b/gremlin/ui/obs_overlay/bindings.py
@@ -1,0 +1,602 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PySide6 import QtCore
+
+import gremlin.joystick_handling
+import gremlin.util
+from gremlin.singleton_decorator import SingletonDecorator
+
+syslog = logging.getLogger("system")
+
+_logged_bind_errors: set[str] = set()
+
+
+def _warn_once(key: str, message: str):
+    if key in _logged_bind_errors:
+        return
+    _logged_bind_errors.add(key)
+    try:
+        syslog.warning(message)
+    except RecursionError:
+        pass
+
+
+def _guid_key(value) -> str:
+    if value is None or value == "":
+        return ""
+    try:
+        return gremlin.util.normalize_guid(value) or ""
+    except Exception:
+        return str(value).casefold()
+
+
+def _device_for_binding(binding: dict[str, Any]):
+    source = (binding.get("source") or "physical").casefold()
+    if source == "vjoy":
+        vjoy_id = int(binding.get("vjoy_id") or 0)
+        if vjoy_id:
+            return gremlin.joystick_handling.getDeviceFromVjoyId(vjoy_id)
+    guid = binding.get("device_guid")
+    if not guid:
+        return None
+    try:
+        return gremlin.joystick_handling.getDevice(guid, show_error=False)
+    except Exception:
+        return None
+
+
+def _invert(value: float, enabled: bool) -> float:
+    if not enabled:
+        return value
+    return -value
+
+
+def _proxy_axis_value(vjoy_id: int, axis_id: int) -> float | None:
+    """vJoy output cache. DirectInput does not echo our own SetAxis writes."""
+    try:
+        axis = gremlin.joystick_handling.VJoyProxy()[int(vjoy_id)].axis(int(axis_id))
+        if axis is None:
+            return None
+        return float(axis.value)
+    except Exception:
+        return None
+
+
+def _proxy_hat_direction(vjoy_id: int, input_id: int) -> tuple[int, int] | None:
+    try:
+        hat = gremlin.joystick_handling.VJoyProxy()[int(vjoy_id)].hat(int(input_id))
+        if hat is None:
+            return None
+        direction = hat.direction
+        return (int(direction[0]), int(direction[1]))
+    except Exception:
+        return None
+
+
+def read_axis(binding: dict[str, Any], axis_id: int | None, invert: bool = False) -> float:
+    if not axis_id:
+        return 0.0
+    source = (binding.get("source") or "physical").casefold()
+    try:
+        if source == "vjoy":
+            vjoy_id, _device = _vjoy_target(binding)
+            if not vjoy_id:
+                return 0.0
+            value = _proxy_axis_value(vjoy_id, int(axis_id))
+            if value is None:
+                value = gremlin.joystick_handling.get_axis(vjoy_id, int(axis_id))
+        else:
+            guid = binding.get("device_guid")
+            if not guid:
+                return 0.0
+            value = gremlin.joystick_handling.get_axis(guid, int(axis_id))
+        if value is None:
+            return 0.0
+        return _invert(float(value), invert)
+    except RecursionError:
+        return 0.0
+    except Exception as err:
+        _warn_once(f"axis:{source}:{binding.get('device_guid')}:{axis_id}", f"OBS OVERLAY: axis read failed: {err}")
+        return 0.0
+
+
+def read_button(binding: dict[str, Any]) -> bool:
+    source = (binding.get("source") or "physical").casefold()
+    if source == "state":
+        try:
+            from gremlin.ui import state_device
+
+            name = binding.get("state_name") or ""
+            value = state_device.StateData().getValue(name)
+            return bool(value)
+        except Exception as err:
+            _warn_once(f"state:{binding.get('state_name')}", f"OBS OVERLAY: state read failed: {err}")
+            return False
+    input_id = int(binding.get("input_id") or 0)
+    if not input_id:
+        return False
+    try:
+        if source == "vjoy":
+            vjoy_id = int(binding.get("vjoy_id") or 0)
+            if not vjoy_id:
+                return False
+            return bool(gremlin.joystick_handling.get_button(vjoy_id, input_id))
+        guid = binding.get("device_guid")
+        if not guid:
+            return False
+        return bool(gremlin.joystick_handling.get_button(guid, input_id))
+    except Exception as err:
+        _warn_once(f"button:{source}:{binding.get('device_guid')}:{input_id}", f"OBS OVERLAY: button read failed: {err}")
+        return False
+
+
+def read_hat(binding: dict[str, Any]) -> tuple[int, int]:
+    input_id = int(binding.get("input_id") or 0)
+    if not input_id:
+        return (0, 0)
+    source = (binding.get("source") or "physical").casefold()
+    try:
+        if source == "vjoy":
+            vjoy_id, _device = _vjoy_target(binding)
+            if not vjoy_id:
+                return (0, 0)
+            proxy_dir = _proxy_hat_direction(vjoy_id, input_id)
+            if proxy_dir is not None:
+                return proxy_dir
+            return gremlin.joystick_handling.get_hat_position(vjoy_id, input_id)
+        guid = binding.get("device_guid")
+        if not guid:
+            return (0, 0)
+        return gremlin.joystick_handling.get_hat_position(guid, input_id)
+    except Exception as err:
+        _warn_once(f"hat:{source}:{binding.get('device_guid')}:{input_id}", f"OBS OVERLAY: hat read failed: {err}")
+        return (0, 0)
+
+
+def widget_needs_xy(widget_type: str) -> bool:
+    return widget_type in ("axis_stick_square", "axis_stick_circle", "axis_crosshair")
+
+
+def binding_for_axis(item: dict[str, Any], axis: str = "x") -> dict[str, Any]:
+    """X uses `binding`; Y uses `binding_y`, with legacy input_id_y fallback."""
+    x_bind = dict(item.get("binding") or {})
+    if axis != "y":
+        return x_bind
+    y_bind = item.get("binding_y")
+    if isinstance(y_bind, dict) and (
+        y_bind.get("device_guid")
+        or y_bind.get("vjoy_id")
+        or y_bind.get("input_id")
+        or y_bind.get("state_name")
+    ):
+        return dict(y_bind)
+    if x_bind.get("input_id_y"):
+        legacy = dict(x_bind)
+        legacy["input_id"] = x_bind.get("input_id_y")
+        legacy["invert"] = bool(x_bind.get("invert_y"))
+        return legacy
+    return dict(y_bind or x_bind)
+
+
+def binding_source(binding: dict[str, Any] | None) -> str:
+    if not isinstance(binding, dict):
+        return "physical"
+    source = (binding.get("source") or "physical").casefold()
+    if source == "state" or (binding.get("input_type") or "").casefold() == "state":
+        return "state"
+    if source == "vjoy":
+        return "vjoy"
+    return "physical"
+
+
+def binding_is_configured(binding: dict[str, Any] | None) -> bool:
+    if not isinstance(binding, dict):
+        return False
+    source = (binding.get("source") or "physical").casefold()
+    if source == "state" or (binding.get("input_type") or "").casefold() == "state":
+        return bool(str(binding.get("state_name") or "").strip())
+    try:
+        return int(binding.get("input_id") or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _vjoy_target(binding: dict[str, Any] | None) -> tuple[int, Any]:
+    """Resolve a vJoy device from source=vjoy or a virtual device GUID."""
+    binding = binding or {}
+    try:
+        vjoy_id = int(binding.get("vjoy_id") or 0)
+    except (TypeError, ValueError):
+        vjoy_id = 0
+    device = None
+    if vjoy_id:
+        try:
+            device = gremlin.joystick_handling.getDeviceFromVjoyId(vjoy_id)
+        except Exception:
+            device = None
+    if device is None:
+        guid = binding.get("device_guid")
+        if guid:
+            try:
+                device = gremlin.joystick_handling.getDevice(guid, show_error=False)
+            except Exception:
+                device = None
+    if vjoy_id > 0:
+        return vjoy_id, device
+    if device is not None:
+        try:
+            vjoy_id = int(getattr(device, "vjoy_id", 0) or 0)
+        except (TypeError, ValueError):
+            vjoy_id = 0
+        if vjoy_id > 0 and getattr(device, "is_virtual", False):
+            return vjoy_id, device
+    if (binding.get("source") or "").casefold() == "vjoy":
+        try:
+            devices = gremlin.joystick_handling.vjoy_devices(connected_only=False) or []
+        except Exception:
+            devices = []
+        if devices:
+            device = devices[0]
+            try:
+                vjoy_id = int(getattr(device, "vjoy_id", 0) or 0)
+            except (TypeError, ValueError):
+                vjoy_id = 0
+            if vjoy_id > 0:
+                return vjoy_id, device
+    return 0, None
+
+
+def binding_is_writable(binding: dict[str, Any] | None) -> bool:
+    """True when touch may write this binding (vJoy or GEX state, never physical)."""
+    if not binding_is_configured(binding):
+        return False
+    if binding_source(binding) == "state":
+        return True
+    return vjoy_binding_writable(binding)
+
+
+def vjoy_binding_writable(binding: dict[str, Any] | None) -> bool:
+    if not binding_is_configured(binding):
+        return False
+    if binding_source(binding) == "state":
+        return False
+    vjoy_id, _device = _vjoy_target(binding)
+    return vjoy_id > 0
+
+
+def widget_accepts_touch(item: dict[str, Any] | None) -> bool:
+    if not item or not item.get("visible", True):
+        return False
+    widget_type = item.get("type")
+    if widget_type in ("label", "panel", "shape", "image", "streamdeck"):
+        return False
+    if widget_type == "button":
+        return binding_is_writable(item.get("binding"))
+    if widget_type == "hat":
+        return vjoy_binding_writable(item.get("binding"))
+    if widget_needs_xy(widget_type):
+        return vjoy_binding_writable(binding_for_axis(item, "x")) or vjoy_binding_writable(binding_for_axis(item, "y"))
+    return vjoy_binding_writable(item.get("binding"))
+
+
+def _clamp_axis(value: float) -> float:
+    return max(-1.0, min(1.0, float(value)))
+
+
+def write_axis(binding: dict[str, Any] | None, value: float) -> bool:
+    if not vjoy_binding_writable(binding):
+        return False
+    binding = binding or {}
+    try:
+        axis_id = int(binding.get("input_id") or 0)
+    except (TypeError, ValueError):
+        axis_id = 0
+    vjoy_id, _device = _vjoy_target(binding)
+    if axis_id <= 0 or vjoy_id <= 0:
+        return False
+    raw = _clamp_axis(value)
+    if binding.get("invert"):
+        raw = -raw
+    try:
+        gremlin.joystick_handling.VJoyProxy()[vjoy_id].axis(axis_id).value = raw
+        return True
+    except Exception as err:
+        _warn_once(f"write-axis:{vjoy_id}:{axis_id}", f"OBS OVERLAY: axis write failed: {err}")
+        return False
+
+
+def write_button(binding: dict[str, Any] | None, pressed: bool) -> bool:
+    if not binding_is_writable(binding):
+        return False
+    binding = binding or {}
+    source = binding_source(binding)
+    if source == "state":
+        try:
+            from gremlin.ui import state_device
+
+            name = str(binding.get("state_name") or "").strip()
+            if not name:
+                return False
+            state_device.StateData().setValue(name, bool(pressed), emit=True, force=True)
+            return True
+        except Exception as err:
+            _warn_once(f"write-state:{binding.get('state_name')}", f"OBS OVERLAY: state write failed: {err}")
+            return False
+    try:
+        input_id = int(binding.get("input_id") or 0)
+    except (TypeError, ValueError):
+        input_id = 0
+    vjoy_id, _device = _vjoy_target(binding)
+    if vjoy_id <= 0 or input_id <= 0:
+        return False
+    try:
+        gremlin.joystick_handling.VJoyProxy()[vjoy_id].button(input_id).is_pressed = bool(pressed)
+        return True
+    except Exception as err:
+        _warn_once(f"write-button:{vjoy_id}:{input_id}", f"OBS OVERLAY: button write failed: {err}")
+        return False
+
+
+def toggle_state(binding: dict[str, Any] | None) -> bool | None:
+    """Invert a GEX state. Returns the new raw value, or None if it did not write."""
+    if binding_source(binding) != "state" or not binding_is_configured(binding):
+        return None
+    new_value = not read_button(binding or {})
+    if write_button(binding, new_value):
+        return new_value
+    return None
+
+
+def write_hat(binding: dict[str, Any] | None, direction: tuple[int, int]) -> bool:
+    if not vjoy_binding_writable(binding):
+        return False
+    binding = binding or {}
+    try:
+        input_id = int(binding.get("input_id") or 0)
+    except (TypeError, ValueError):
+        input_id = 0
+    vjoy_id, device = _vjoy_target(binding)
+    if vjoy_id <= 0 or input_id <= 0:
+        return False
+    nx, ny = int(direction[0]), int(direction[1])
+    if binding.get("invert"):
+        nx = -nx
+    if binding.get("invert_y"):
+        ny = -ny
+    try:
+        hat_count = int(getattr(device, "hat_count", 0) or 0) if device is not None else 4
+        if hat_count and not (0 < input_id <= hat_count):
+            return False
+        gremlin.joystick_handling.VJoyProxy()[vjoy_id].hat(input_id).direction = (nx, ny)
+        return True
+    except Exception as err:
+        _warn_once(f"write-hat:{vjoy_id}:{input_id}", f"OBS OVERLAY: hat write failed: {err}")
+        return False
+
+
+def read_toggle_active(binding: dict[str, Any] | None) -> bool:
+    """True while the assigned toggle input is held / past threshold."""
+    if not binding_is_configured(binding):
+        return False
+    binding = binding or {}
+    kind = (binding.get("input_type") or "button").casefold()
+    source = (binding.get("source") or "physical").casefold()
+    invert = bool(binding.get("invert"))
+    if source == "state" or kind == "state":
+        value = read_button(binding)
+    elif kind == "axis":
+        value = read_axis(binding, binding.get("input_id"), invert) >= 0.5
+        invert = False
+    elif kind == "hat":
+        x, y = read_hat(binding)
+        value = x != 0 or y != 0
+    else:
+        value = read_button(binding)
+    return (not value) if invert else bool(value)
+
+
+def _streamdeck_overlay_value(item: dict[str, Any]):
+    """Fingerprint so overlay views redraw when the mirrored deck changes."""
+    try:
+        from gremlin.ui.streamdeck_device import StreamDeckBridge, normalize_page
+
+        bridge = StreamDeckBridge()
+        style = item.get("style") or {}
+        device_id = bridge.resolve_overlay_device_id(str(style.get("streamdeck_device_id") or ""))
+        follow = bool(style.get("streamdeck_follow_page", True))
+        if follow:
+            page = bridge.get_active_page(device_id) if device_id else 1
+        else:
+            page = normalize_page(style.get("streamdeck_page") or 1)
+        held = tuple(sorted(bridge.held_slot_keys(device_id))) if device_id else ()
+        connected = bool(device_id and device_id in bridge.devices)
+        return (
+            device_id,
+            page,
+            held,
+            connected,
+            bridge.overlay_generation(),
+            bool(bridge.plugin_is_connected),
+        )
+    except Exception:
+        return ("", 0, (), False, 0, False)
+
+
+def read_widget_value(item: dict[str, Any]):
+    """Return the live value used by a widget: float, (x,y), bool, or hat tuple."""
+    widget_type = item.get("type")
+    binding = item.get("binding") or {}
+    invert = bool(binding.get("invert"))
+    if widget_type in ("label", "panel", "shape", "image"):
+        return None
+    if widget_type == "streamdeck":
+        return _streamdeck_overlay_value(item)
+    if widget_type == "button":
+        pressed = read_button(binding)
+        return (not pressed) if invert else pressed
+    if widget_type == "hat":
+        x, y = read_hat(binding)
+        if invert:
+            x = -x
+        if bool(binding.get("invert_y")):
+            y = -y
+        return (x, y)
+    if widget_needs_xy(widget_type):
+        x_bind = binding_for_axis(item, "x")
+        y_bind = binding_for_axis(item, "y")
+        x = read_axis(x_bind, x_bind.get("input_id"), bool(x_bind.get("invert")))
+        y = read_axis(y_bind, y_bind.get("input_id"), bool(y_bind.get("invert")))
+        return (x, y)
+    return read_axis(binding, binding.get("input_id"), invert)
+
+
+@SingletonDecorator
+class OverlayValueBus(QtCore.QObject):
+    """Live physical / vJoy / state values for overlay widgets.
+
+    Steady 60 Hz DirectInput poll. Per-event UI callbacks are not used:
+    HID packets from every device starve Qt's paint timer and look worse.
+    """
+
+    values_changed = QtCore.Signal(object)
+    POLL_INTERVAL_MS = 16  # ~60 Hz
+
+    def __init__(self):
+        super().__init__()
+        self._refcount = 0
+        self._connected = False
+        self._poll = QtCore.QTimer(self)
+        self._poll.setTimerType(QtCore.Qt.TimerType.PreciseTimer)
+        self._poll.setInterval(self.POLL_INTERVAL_MS)
+        self._poll.timeout.connect(self.refresh)
+        self._cache: dict[str, Any] = {}
+        self._locked: set[str] = set()
+        self._scene_widgets: list[dict[str, Any]] = []
+        self._streamdeck_hooked = False
+        self._streamdeck_bridge = None
+
+    def attach(self, widgets: list[dict[str, Any]] | None = None):
+        if widgets is not None:
+            self._scene_widgets = widgets
+        self._refcount += 1
+        if self._refcount == 1:
+            self._connect()
+        self.refresh()
+
+    def detach(self):
+        self._refcount = max(0, self._refcount - 1)
+        if self._refcount == 0:
+            self._disconnect()
+
+    def set_widgets(self, widgets: list[dict[str, Any]]):
+        self._scene_widgets = widgets
+
+    def _connect(self):
+        if self._connected:
+            return
+        try:
+            from gremlin.ui import state_device
+
+            state_device.StateData().changed.connect(self.refresh)
+        except Exception:
+            pass
+        self._hook_streamdeck(True)
+        self._poll.start()
+        self._connected = True
+
+    def _disconnect(self):
+        if not self._connected:
+            return
+        try:
+            from gremlin.ui import state_device
+
+            state_device.StateData().changed.disconnect(self.refresh)
+        except Exception:
+            pass
+        self._hook_streamdeck(False)
+        self._poll.stop()
+        self._connected = False
+
+    def _hook_streamdeck(self, enable: bool):
+        if enable == self._streamdeck_hooked:
+            return
+        try:
+            from gremlin.ui.streamdeck_device import StreamDeckBridge
+
+            bridge = StreamDeckBridge()
+        except Exception:
+            return
+        if enable:
+            try:
+                bridge.devices_changed.connect(self._on_streamdeck_event)
+                bridge.virtual_page_changed.connect(self._on_streamdeck_event)
+                bridge.inputs_changed.connect(self._on_streamdeck_event)
+                bridge.slot_pressed.connect(self._on_streamdeck_event)
+            except Exception:
+                return
+            self._streamdeck_bridge = bridge
+            self._streamdeck_hooked = True
+            return
+        try:
+            if self._streamdeck_bridge is not None:
+                self._streamdeck_bridge.devices_changed.disconnect(self._on_streamdeck_event)
+                self._streamdeck_bridge.virtual_page_changed.disconnect(self._on_streamdeck_event)
+                self._streamdeck_bridge.inputs_changed.disconnect(self._on_streamdeck_event)
+                self._streamdeck_bridge.slot_pressed.disconnect(self._on_streamdeck_event)
+        except Exception:
+            pass
+        self._streamdeck_bridge = None
+        self._streamdeck_hooked = False
+
+    def _on_streamdeck_event(self, *args):
+        """Stream Deck paint reads live bridge state; force every overlay view to redraw."""
+        self.refresh()
+        self.values_changed.emit([])
+
+    def refresh(self, *args):
+        changed_ids = []
+        for item in self._scene_widgets:
+            widget_id = item.get("id")
+            if widget_id in self._locked:
+                continue
+            value = read_widget_value(item)
+            if self._cache.get(widget_id) != value:
+                self._cache[widget_id] = value
+                changed_ids.append(widget_id)
+        if changed_ids:
+            self.values_changed.emit(changed_ids)
+
+    def value_for(self, item: dict[str, Any]):
+        widget_id = item.get("id")
+        if widget_id in self._cache:
+            return self._cache[widget_id]
+        value = read_widget_value(item)
+        self._cache[widget_id] = value
+        return value
+
+    def poke(self, widget_id: str, value, lock: bool = False):
+        """Push a value immediately so paint does not wait for the next poll."""
+        if not widget_id:
+            return
+        if lock:
+            self._locked.add(widget_id)
+        if self._cache.get(widget_id) == value:
+            return
+        self._cache[widget_id] = value
+        self.values_changed.emit([widget_id])
+
+    def unlock(self, widget_id: str | None):
+        if widget_id:
+            self._locked.discard(widget_id)

--- a/gremlin/ui/obs_overlay/designer.py
+++ b/gremlin/ui/obs_overlay/designer.py
@@ -13,6 +13,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 import gremlin.event_handler
 import gremlin.ui.ui_common
+import gremlin.util
 from gremlin.ui.ui_common import Color, QTabHeader
 
 from .inspector import OverlayInspector
@@ -832,6 +833,10 @@ class OverlayDesignerWidget(QtWidgets.QWidget):
         return row
 
     def _on_scene_ui(self):
+        app = QtWidgets.QApplication.instance()
+        if app is not None and QtCore.QThread.currentThread() is not app.thread():
+            gremlin.util.InvokeUiMethod(self._on_scene_ui)
+            return
         self._refresh_page_tabs()
         self._refresh_interactive_box()
         self._refresh_overlay_button()
@@ -1112,6 +1117,10 @@ class OverlayDesignerWidget(QtWidgets.QWidget):
         button.setText("Hide overlay" if visible else "Show overlay")
 
     def refresh_profile_title(self):
+        app = QtWidgets.QApplication.instance()
+        if app is not None and QtCore.QThread.currentThread() is not app.thread():
+            gremlin.util.InvokeUiMethod(self.refresh_profile_title)
+            return
         self._title.setText(f"Overlay — {profile_display_name()}")
         self._refresh_overlay_button()
 

--- a/gremlin/ui/obs_overlay/designer.py
+++ b/gremlin/ui/obs_overlay/designer.py
@@ -1,0 +1,1146 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+import gremlin.event_handler
+import gremlin.ui.ui_common
+from gremlin.ui.ui_common import Color, QTabHeader
+
+from .inspector import OverlayInspector
+from .model import DEFAULT_SIZES, PALETTE_GROUPS, OverlayScene, is_interactive_overlay, profile_display_name
+from .overlay_window import OverlayView
+from .shapes import (
+    _abs_point,
+    _handle_point,
+    closest_segment,
+    ensure_shape_points,
+    insert_shape_point,
+    normalize_shape_kind,
+    remove_shape_point,
+    scene_to_normalized,
+    uses_editable_points,
+)
+from .templates import (
+    TEMPLATES,
+    delete_user_template,
+    list_user_templates,
+    save_user_template,
+    update_user_template,
+)
+
+
+WIDGET_TITLES = {
+    "axis_bar": "Bar",
+    "axis_radio": "Radio",
+    "axis_fader": "Fader",
+    "axis_radial": "Radial",
+    "axis_encoder": "Encoder",
+    "axis_stick_square": "X/Y",
+    "axis_crosshair": "Radar",
+    "axis_stick_circle": "Circular",
+    "button": "Button",
+    "hat": "Hat",
+    "label": "Label",
+    "shape": "Shape",
+    "image": "Image",
+    "streamdeck": "Stream Deck",
+}
+
+
+class TemplateButton(QtWidgets.QPushButton):
+    """Built-in or saved template. Saved templates can be updated or deleted from a right-click menu."""
+
+    apply_requested = QtCore.Signal()
+    update_requested = QtCore.Signal()
+    delete_requested = QtCore.Signal()
+
+    def __init__(self, label: str, editable: bool = False, parent=None):
+        super().__init__(label, parent)
+        self._editable = editable
+        self.clicked.connect(lambda _=False: self.apply_requested.emit())
+        if editable:
+            self.setToolTip("Click to apply. Right-click to update with the current widgets or delete.")
+            self.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
+        else:
+            self.setToolTip("Click to add this template to the canvas.")
+            self.setContextMenuPolicy(QtCore.Qt.NoContextMenu)
+
+    def contextMenuEvent(self, event: QtGui.QContextMenuEvent):
+        if not self._editable:
+            return
+        menu = QtWidgets.QMenu(self)
+        update_action = menu.addAction("Update with current widgets")
+        update_action.triggered.connect(lambda _=False: self.update_requested.emit())
+        delete_action = menu.addAction("Delete template")
+        delete_action.triggered.connect(lambda _=False: self.delete_requested.emit())
+        menu.exec(event.globalPos())
+
+
+class DesignerCanvas(OverlayView):
+    """Interactive canvas: select, move, resize, rubber-band."""
+
+    def __init__(self, scene: OverlayScene, parent=None):
+        super().__init__(scene, interactive=True, parent=parent)
+        self._mode = None
+        self._handle = -1
+        self._guide_id = None
+        self._last = QtCore.QPointF()
+        self._origin = QtCore.QPointF()
+        self._start_geom = {}
+        self._start_geoms: dict[str, dict] = {}
+        self._start_bounds: dict = {}
+        self._shape_vertex = None
+        self._shape_handle = None
+        self.setAcceptDrops(False)
+        self.setCursor(QtCore.Qt.ArrowCursor)
+        self.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
+        self.scene.selection_changed.connect(self._clear_shape_vertex)
+
+    def _clear_shape_vertex(self):
+        if self._mode == "shape":
+            return
+        self._shape_vertex = None
+        self._shape_handle = None
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent):
+        if event.button() != QtCore.Qt.LeftButton:
+            return
+        self.setFocus()
+        pos = self.map_to_scene(event.position())
+        vertex = self.shape_handle_at(pos)
+        if vertex is not None:
+            self.scene.push_undo()
+            self._mode = "shape"
+            self._shape_vertex, self._shape_handle = vertex
+            self.update()
+            return
+        widget_id, handle = self.handle_at(pos)
+        if handle >= 0:
+            self.scene.push_undo()
+            self._mode = "resize"
+            self._handle = handle
+            self._last = pos
+            self._start_geoms = {}
+            for sid in self.scene.selected_ids:
+                it = self.scene.widget_by_id(sid)
+                if it:
+                    self._start_geoms[sid] = {
+                        "x": float(it.get("x") or 0),
+                        "y": float(it.get("y") or 0),
+                        "w": float(it.get("w") or 1),
+                        "h": float(it.get("h") or 1),
+                    }
+            bounds = self._selected_bounds()
+            self._start_bounds = (
+                {"x": bounds.x(), "y": bounds.y(), "w": bounds.width(), "h": bounds.height()}
+                if bounds is not None
+                else {}
+            )
+            item = self.scene.widget_by_id(widget_id) or self.scene.primary_selection()
+            self._start_geom = dict(item) if item else {}
+            return
+        hit = self.scene.hit_test(pos.x(), pos.y())
+        if hit:
+            additive = bool(event.modifiers() & QtCore.Qt.ShiftModifier)
+            group_ids = self.scene.expand_group_ids([hit["id"]])
+            if additive:
+                self.scene.set_selection(group_ids, additive=True)
+                self.scene.set_selection(self.scene.expand_group_ids(self.scene.selected_ids))
+            elif hit["id"] not in self.scene.selected_ids:
+                self.scene.set_selection(group_ids)
+            self.scene.push_undo()
+            self._mode = "move"
+            self._last = pos
+            self.setCursor(QtCore.Qt.SizeAllCursor)
+            return
+        guide = self.guide_at(pos)
+        if guide:
+            self.scene.push_undo()
+            self._mode = "guide"
+            self._guide_id = guide.get("id")
+            self.setCursor(QtCore.Qt.SizeVerCursor if guide.get("axis") == "h" else QtCore.Qt.SizeHorCursor)
+            return
+        if not (event.modifiers() & QtCore.Qt.ShiftModifier):
+            self.scene.set_selection([])
+        self._mode = "rubber"
+        self._origin = pos
+        self._rubber = QtCore.QRectF(pos, pos)
+        self.update()
+
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent):
+        pos = self.map_to_scene(event.position())
+        if self._mode == "move":
+            dx = pos.x() - self._last.x()
+            dy = pos.y() - self._last.y()
+            self.scene.move_selected(int(dx), int(dy), snap=True)
+            self._last = pos
+        elif self._mode == "shape":
+            self._drag_shape_handle(pos, event.modifiers())
+        elif self._mode == "resize":
+            self._resize_to(pos, bool(event.modifiers() & QtCore.Qt.ShiftModifier))
+        elif self._mode == "guide":
+            self._drag_guide(pos)
+        elif self._mode == "rubber":
+            self._rubber = QtCore.QRectF(self._origin, pos)
+            self.update()
+        else:
+            _, handle = self.handle_at(pos)
+            if handle >= 0:
+                self.setCursor(self._resize_cursor(handle))
+                return
+            guide = self.guide_at(pos)
+            if guide:
+                self.setCursor(QtCore.Qt.SizeVerCursor if guide.get("axis") == "h" else QtCore.Qt.SizeHorCursor)
+            else:
+                self.setCursor(QtCore.Qt.ArrowCursor)
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent):
+        if self._mode == "rubber":
+            ids = self.scene.widgets_in_rect(
+                self._rubber.x(), self._rubber.y(), self._rubber.width(), self._rubber.height()
+            )
+            ids = self.scene.expand_group_ids(ids)
+            self.scene.set_selection(ids, additive=bool(event.modifiers() & QtCore.Qt.ShiftModifier))
+            if event.modifiers() & QtCore.Qt.ShiftModifier:
+                self.scene.set_selection(self.scene.expand_group_ids(self.scene.selected_ids))
+            self._rubber = QtCore.QRectF()
+        self._mode = None
+        self._handle = -1
+        self._guide_id = None
+        self._shape_handle = None
+        self.setCursor(QtCore.Qt.ArrowCursor)
+        self.update()
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent):
+        key = event.key()
+        mods = event.modifiers()
+        step = 8 if self.scene.canvas.get("snap_to_grid") else 1
+        if mods & QtCore.Qt.ShiftModifier:
+            step *= 4
+        if key == QtCore.Qt.Key_Delete:
+            if self._delete_shape_vertex():
+                return
+            self.scene.remove_selected()
+        elif key == QtCore.Qt.Key_D and mods & QtCore.Qt.ControlModifier:
+            self.scene.duplicate_selected()
+        elif key == QtCore.Qt.Key_G and mods & QtCore.Qt.ControlModifier:
+            if mods & QtCore.Qt.ShiftModifier:
+                self.scene.ungroup_selected()
+            else:
+                self.scene.group_selected()
+        elif key == QtCore.Qt.Key_A and mods & QtCore.Qt.ControlModifier:
+            self.scene.set_selection([w["id"] for w in self.scene.widgets])
+        elif key == QtCore.Qt.Key_Z and mods & QtCore.Qt.ControlModifier:
+            if mods & QtCore.Qt.ShiftModifier:
+                self.scene.redo()
+            else:
+                self.scene.undo()
+        elif key == QtCore.Qt.Key_Y and mods & QtCore.Qt.ControlModifier:
+            self.scene.redo()
+        elif key == QtCore.Qt.Key_Left:
+            self.scene.push_undo()
+            self.scene.move_selected(-step, 0)
+        elif key == QtCore.Qt.Key_Right:
+            self.scene.push_undo()
+            self.scene.move_selected(step, 0)
+        elif key == QtCore.Qt.Key_Up:
+            self.scene.push_undo()
+            self.scene.move_selected(0, -step)
+        elif key == QtCore.Qt.Key_Down:
+            self.scene.push_undo()
+            self.scene.move_selected(0, step)
+        elif key == QtCore.Qt.Key_0 and mods & QtCore.Qt.ControlModifier:
+            self._zoom_at(1.0)
+        elif (key in (QtCore.Qt.Key_Plus, QtCore.Qt.Key_Equal)) and mods & QtCore.Qt.ControlModifier:
+            self._zoom_at(self.zoom * 1.1)
+        elif key == QtCore.Qt.Key_Minus and mods & QtCore.Qt.ControlModifier:
+            self._zoom_at(self.zoom / 1.1)
+        else:
+            super().keyPressEvent(event)
+
+    def contextMenuEvent(self, event: QtGui.QContextMenuEvent):
+        pos = self.map_to_scene(event.pos())
+        hit = self.scene.hit_test(pos.x(), pos.y())
+        if hit and hit["id"] not in self.scene.selected_ids:
+            self.scene.set_selection(self.scene.expand_group_ids([hit["id"]]))
+        if not self.scene.selected_ids:
+            return
+        grouped = any(str(item.get("group") or "").strip() for item in self.scene.selected_widgets())
+        menu = QtWidgets.QMenu(self)
+        duplicate = menu.addAction("Duplicate")
+        delete = menu.addAction("Delete")
+        menu.addSeparator()
+        forward = menu.addAction("Bring forward")
+        backward = menu.addAction("Send backward")
+        menu.addSeparator()
+        group = menu.addAction("Group")
+        group.setEnabled(len(self.scene.selected_ids) >= 2)
+        ungroup = menu.addAction("Ungroup")
+        ungroup.setEnabled(grouped)
+        add_point = None
+        delete_point = None
+        item = self.scene.primary_selection()
+        if uses_editable_points(item):
+            menu.addSeparator()
+            add_point = menu.addAction("Add point")
+            delete_point = menu.addAction("Delete point")
+            delete_point.setEnabled(self._shape_vertex is not None)
+        chosen = menu.exec(event.globalPos())
+        if chosen is duplicate:
+            self.scene.duplicate_selected()
+        elif chosen is delete:
+            self.scene.remove_selected()
+        elif chosen is forward:
+            self.scene.bring_forward()
+        elif chosen is backward:
+            self.scene.send_backward()
+        elif chosen is group:
+            self.scene.group_selected()
+        elif chosen is ungroup:
+            self.scene.ungroup_selected()
+        elif chosen is add_point:
+            pos = self.map_to_scene(event.pos())
+            self.scene.push_undo()
+            index, _dist = closest_segment(item, pos)
+            self._shape_vertex = insert_shape_point(item, index, pos)
+            self.scene._dirty = True
+            self.scene.changed.emit()
+        elif chosen is delete_point:
+            self._delete_shape_vertex()
+
+    def wheelEvent(self, event: QtGui.QWheelEvent):
+        if event.modifiers() & QtCore.Qt.ControlModifier:
+            delta = event.angleDelta().y()
+            if delta:
+                factor = 1.1 if delta > 0 else 1.0 / 1.1
+                self._zoom_at(self.zoom * factor, event.position())
+                event.accept()
+                return
+        event.ignore()
+
+    def _zoom_at(self, zoom: float, widget_pos: QtCore.QPointF | None = None):
+        scroll = self.parent()
+        while scroll is not None and not isinstance(scroll, QtWidgets.QScrollArea):
+            scroll = scroll.parent()
+        old_zoom = self.zoom
+        if widget_pos is None:
+            self.set_zoom(zoom)
+            return
+        scene_pos = QtCore.QPointF(widget_pos.x() / max(old_zoom, 0.01), widget_pos.y() / max(old_zoom, 0.01))
+        viewport_pos = None
+        if scroll is not None:
+            viewport_pos = self.mapTo(scroll.viewport(), widget_pos.toPoint())
+        self.set_zoom(zoom)
+        if scroll is None or viewport_pos is None:
+            return
+        new_widget = QtCore.QPoint(int(scene_pos.x() * self.zoom), int(scene_pos.y() * self.zoom))
+        scroll.horizontalScrollBar().setValue(new_widget.x() - viewport_pos.x())
+        scroll.verticalScrollBar().setValue(new_widget.y() - viewport_pos.y())
+
+    def _resize_cursor(self, handle: int):
+        mapping = {
+            0: QtCore.Qt.SizeFDiagCursor,
+            1: QtCore.Qt.SizeVerCursor,
+            2: QtCore.Qt.SizeBDiagCursor,
+            3: QtCore.Qt.SizeHorCursor,
+            4: QtCore.Qt.SizeFDiagCursor,
+            5: QtCore.Qt.SizeVerCursor,
+            6: QtCore.Qt.SizeBDiagCursor,
+            7: QtCore.Qt.SizeHorCursor,
+        }
+        return mapping.get(handle, QtCore.Qt.ArrowCursor)
+
+    def _resize_to(self, pos: QtCore.QPointF, keep_aspect: bool = False):
+        if len(self._start_geoms) > 1 and self._start_bounds:
+            self._resize_group_to(pos, keep_aspect)
+            return
+        item = self.scene.primary_selection()
+        if not item or not self._start_geom:
+            return
+        ox = float(self._start_geom["x"])
+        oy = float(self._start_geom["y"])
+        ow = float(self._start_geom["w"])
+        oh = float(self._start_geom["h"])
+        x, y, w, h = self._bounds_from_handle(ox, oy, ow, oh, pos)
+        if keep_aspect:
+            x, y, w, h = self._lock_aspect(x, y, w, h, ox, oy, ow, oh)
+            x, y, w, h = self._snap_locked_geom(x, y, w, h, ox, oy, ow, oh)
+            item["x"] = int(round(x))
+            item["y"] = int(round(y))
+            item["w"] = max(8, int(round(w)))
+            item["h"] = max(8, int(round(h)))
+        else:
+            item["x"] = self.scene.snap_value(x)
+            item["y"] = self.scene.snap_value(y)
+            item["w"] = max(8, self.scene.snap_value(w))
+            item["h"] = max(8, self.scene.snap_value(h))
+            x_edges, y_edges = self._handle_edges()
+            gx, gy, gw, gh = self.scene.snap_geom_to_guides(
+                float(item["x"]),
+                float(item["y"]),
+                float(item["w"]),
+                float(item["h"]),
+                x_edges=x_edges,
+                y_edges=y_edges,
+                mode="resize",
+            )
+            item["x"] = int(round(gx))
+            item["y"] = int(round(gy))
+            item["w"] = max(8, int(round(gw)))
+            item["h"] = max(8, int(round(gh)))
+        self.scene._dirty = True
+        self.scene.changed.emit()
+
+    def _handle_edges(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        handle = self._handle
+        x_edges = ()
+        y_edges = ()
+        if handle in (0, 6, 7):
+            x_edges = ("left",)
+        elif handle in (2, 3, 4):
+            x_edges = ("right",)
+        if handle in (0, 1, 2):
+            y_edges = ("top",)
+        elif handle in (4, 5, 6):
+            y_edges = ("bottom",)
+        return x_edges, y_edges
+
+    def _bounds_from_handle(self, x0: float, y0: float, w0: float, h0: float, pos: QtCore.QPointF) -> tuple[float, float, float, float]:
+        x1, y1 = x0 + w0, y0 + h0
+        px, py = pos.x(), pos.y()
+        handle = self._handle
+        if handle in (0, 6, 7):
+            x0 = px
+        if handle in (2, 3, 4):
+            x1 = px
+        if handle in (0, 1, 2):
+            y0 = py
+        if handle in (4, 5, 6):
+            y1 = py
+        x, y = min(x0, x1), min(y0, y1)
+        w, h = max(8.0, abs(x1 - x0)), max(8.0, abs(y1 - y0))
+        return x, y, w, h
+
+    def _lock_aspect(self, x: float, y: float, w: float, h: float, ox: float, oy: float, ow: float, oh: float):
+        """Keep the original aspect, anchored on the opposite edge or corner."""
+        ow = max(1.0, ow)
+        oh = max(1.0, oh)
+        ratio = ow / oh
+        handle = self._handle
+        right = ox + ow
+        bottom = oy + oh
+        cx = ox + ow / 2.0
+        cy = oy + oh / 2.0
+        min_scale = max(8.0 / ow, 8.0 / oh)
+        if handle in (0, 2, 4, 6):
+            scale = max(w / ow, h / oh, min_scale)
+            w = ow * scale
+            h = oh * scale
+            if handle == 0:
+                x, y = right - w, bottom - h
+            elif handle == 2:
+                x, y = ox, bottom - h
+            elif handle == 4:
+                x, y = ox, oy
+            else:
+                x, y = right - w, oy
+            return x, y, w, h
+        if handle in (3, 7):
+            w = max(8.0, w)
+            h = max(8.0, w / ratio)
+            y = cy - h / 2.0
+            x = (right - w) if handle == 7 else ox
+            return x, y, w, h
+        h = max(8.0, h)
+        w = max(8.0, h * ratio)
+        x = cx - w / 2.0
+        y = (bottom - h) if handle == 1 else oy
+        return x, y, w, h
+
+    def _snap_locked_geom(self, x: float, y: float, w: float, h: float, ox: float, oy: float, ow: float, oh: float):
+        """Snap an aspect-locked rect to the grid without stretching it."""
+        ow = max(1.0, ow)
+        oh = max(1.0, oh)
+        ratio = ow / oh
+        sw = max(8.0, float(self.scene.snap_value(w)))
+        sh = max(8.0, float(self.scene.snap_value(h)))
+        from_w = (sw, max(8.0, sw / ratio))
+        from_h = (max(8.0, sh * ratio), sh)
+        err_w = abs(from_w[0] - w) + abs(from_w[1] - h)
+        err_h = abs(from_h[0] - w) + abs(from_h[1] - h)
+        nw, nh = from_w if err_w <= err_h else from_h
+        return self._lock_aspect(x, y, nw, nh, ox, oy, ow, oh)
+
+    def _resize_group_to(self, pos: QtCore.QPointF, keep_aspect: bool = False):
+        ox = float(self._start_bounds.get("x") or 0)
+        oy = float(self._start_bounds.get("y") or 0)
+        ow = max(1.0, float(self._start_bounds.get("w") or 1))
+        oh = max(1.0, float(self._start_bounds.get("h") or 1))
+        nx, ny, nw, nh = self._bounds_from_handle(ox, oy, ow, oh, pos)
+        if keep_aspect:
+            nx, ny, nw, nh = self._lock_aspect(nx, ny, nw, nh, ox, oy, ow, oh)
+        else:
+            x_edges, y_edges = self._handle_edges()
+            nx, ny, nw, nh = self.scene.snap_geom_to_guides(nx, ny, nw, nh, x_edges=x_edges, y_edges=y_edges, mode="resize")
+        min_w = min((max(1.0, g["w"]) for g in self._start_geoms.values()), default=8.0)
+        min_h = min((max(1.0, g["h"]) for g in self._start_geoms.values()), default=8.0)
+        if keep_aspect:
+            scale = max(nw / ow, nh / oh, 8.0 / min_w, 8.0 / min_h)
+            nw, nh = ow * scale, oh * scale
+            nx, ny, nw, nh = self._lock_aspect(nx, ny, nw, nh, ox, oy, ow, oh)
+            nx, ny, nw, nh = self._snap_locked_geom(nx, ny, nw, nh, ox, oy, ow, oh)
+        else:
+            nw = max(nw, 8.0 * ow / min_w)
+            nh = max(nh, 8.0 * oh / min_h)
+        sx = nw / ow
+        sy = nh / oh
+        self.scene._suspend += 1
+        try:
+            for widget_id, geom in self._start_geoms.items():
+                item = self.scene.widget_by_id(widget_id)
+                if not item:
+                    continue
+                item["x"] = int(round(nx + (geom["x"] - ox) * sx))
+                item["y"] = int(round(ny + (geom["y"] - oy) * sy))
+                item["w"] = max(8, int(round(geom["w"] * sx)))
+                item["h"] = max(8, int(round(geom["h"] * sy)))
+        finally:
+            self.scene._suspend = max(0, self.scene._suspend - 1)
+            self.scene._dirty = True
+            self.scene._emit()
+
+    def _drag_guide(self, pos: QtCore.QPointF):
+        guide = self.scene.guide_by_id(self._guide_id) if self._guide_id else None
+        if not guide:
+            return
+        cw, ch = self.canvas_size()
+        if guide.get("axis") == "h":
+            value = 0.0 if ch <= 0 else pos.y() / ch
+        else:
+            value = 0.0 if cw <= 0 else pos.x() / cw
+        self.scene.update_guide(guide["id"], position=max(0.0, min(1.0, value)))
+
+    def mouseDoubleClickEvent(self, event: QtGui.QMouseEvent):
+        if event.button() != QtCore.Qt.LeftButton:
+            return
+        pos = self.map_to_scene(event.position())
+        item = self.scene.primary_selection()
+        if not uses_editable_points(item):
+            hit = self.scene.hit_test(pos.x(), pos.y())
+            if hit:
+                self.scene.set_selection(self.scene.expand_group_ids([hit["id"]]))
+                item = hit
+        if not uses_editable_points(item):
+            return
+        self.scene.push_undo()
+        index, _dist = closest_segment(item, pos)
+        self._shape_vertex = insert_shape_point(item, index, pos)
+        self._shape_handle = "point"
+        self.scene._dirty = True
+        self.scene.changed.emit()
+
+    def _bezier_handle_indices(self, item: dict, points: list) -> list[int]:
+        kind = normalize_shape_kind((item.get("style") or {}).get("shape_kind"))
+        if kind == "freeform":
+            return list(range(len(points)))
+        if self._shape_vertex is not None and 0 <= self._shape_vertex < len(points):
+            return [self._shape_vertex]
+        return []
+
+    def shape_handle_at(self, pos: QtCore.QPointF):
+        item = self.scene.primary_selection()
+        if not uses_editable_points(item):
+            return None
+        points = ensure_shape_points(item)
+        tol = 7.0 / max(self._zoom, 0.25)
+        for index in self._bezier_handle_indices(item, points):
+            point = points[index]
+            for kind in ("in", "out"):
+                handle = _handle_point(item, point, kind)
+                if abs(pos.x() - handle.x()) <= tol and abs(pos.y() - handle.y()) <= tol:
+                    return index, kind
+        for index, point in enumerate(points):
+            origin = _abs_point(item, point)
+            if abs(pos.x() - origin.x()) <= tol and abs(pos.y() - origin.y()) <= tol:
+                return index, "point"
+        return None
+
+    def _drag_shape_handle(self, pos: QtCore.QPointF, modifiers):
+        item = self.scene.primary_selection()
+        if not uses_editable_points(item) or self._shape_vertex is None:
+            return
+        points = ensure_shape_points(item)
+        if self._shape_vertex < 0 or self._shape_vertex >= len(points):
+            return
+        point = points[self._shape_vertex]
+        if self._shape_handle == "point":
+            nx, ny = scene_to_normalized(item, pos)
+            point["x"] = nx
+            point["y"] = ny
+        else:
+            origin = _abs_point(item, point)
+            width = max(1.0, float(item["w"]))
+            height = max(1.0, float(item["h"]))
+            dx = (pos.x() - origin.x()) / width
+            dy = (pos.y() - origin.y()) / height
+            kind = self._shape_handle or "out"
+            point[f"{kind}_x"] = dx
+            point[f"{kind}_y"] = dy
+            if not (modifiers & QtCore.Qt.AltModifier):
+                other = "in" if kind == "out" else "out"
+                point[f"{other}_x"] = -dx
+                point[f"{other}_y"] = -dy
+        item["points"] = points
+        self.scene._dirty = True
+        self.scene.changed.emit()
+
+    def _delete_shape_vertex(self) -> bool:
+        item = self.scene.primary_selection()
+        if not uses_editable_points(item) or self._shape_vertex is None:
+            return False
+        self.scene.push_undo()
+        if not remove_shape_point(item, self._shape_vertex):
+            return False
+        self._shape_vertex = None
+        self._shape_handle = None
+        self.scene._dirty = True
+        self.scene.changed.emit()
+        return True
+
+    def _paint_selection(self, painter: QtGui.QPainter):
+        super()._paint_selection(painter)
+        item = self.scene.primary_selection()
+        if not uses_editable_points(item):
+            return
+        points = ensure_shape_points(item)
+        hs = 4.0 / max(self._zoom, 0.25)
+        painter.save()
+        for index, point in enumerate(points):
+            origin = _abs_point(item, point)
+            selected = index == self._shape_vertex
+            painter.setPen(QtGui.QPen(QtGui.QColor("#ffe27a" if selected else "#7ec8ff"), 1.2))
+            painter.setBrush(QtGui.QColor("#ffe27a" if selected else "#7ec8ff"))
+            painter.drawEllipse(origin, hs, hs)
+        for index in self._bezier_handle_indices(item, points):
+            point = points[index]
+            origin = _abs_point(item, point)
+            selected = index == self._shape_vertex
+            color = QtGui.QColor("#ffe27a" if selected else "#d4b84a")
+            painter.setPen(QtGui.QPen(color, 1.0, QtCore.Qt.DashLine))
+            for kind in ("in", "out"):
+                handle = _handle_point(item, point, kind)
+                painter.drawLine(origin, handle)
+                painter.setBrush(color)
+                painter.setPen(QtCore.Qt.NoPen)
+                painter.drawEllipse(handle, hs * 0.85, hs * 0.85)
+                painter.setPen(QtGui.QPen(color, 1.0, QtCore.Qt.DashLine))
+        painter.restore()
+
+
+class OverlayDesignerWidget(QtWidgets.QWidget):
+    """Overlay layout editor hosted on the Overlay device tab."""
+
+    def __init__(self, scene: OverlayScene, overlay_manager=None, overlay_callback=None, parent=None):
+        super().__init__(parent)
+        self.scene = scene
+        self._overlay_manager = overlay_manager
+        self._overlay_callback = overlay_callback
+        self.setMinimumSize(640, 480)
+
+        root = QtWidgets.QVBoxLayout(self)
+        root.setContentsMargins(8, 8, 8, 8)
+        self._title = QtWidgets.QLabel()
+        self._title.setStyleSheet("font-weight: bold;")
+        root.addWidget(self._title)
+        self.refresh_profile_title()
+        root.addWidget(self._toolbar())
+        root.addWidget(self._page_bar())
+
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        splitter.addWidget(self._palette())
+        self.canvas = DesignerCanvas(scene)
+        scroll = QtWidgets.QScrollArea()
+        self._canvas_scroll = scroll
+        scroll.setWidgetResizable(False)
+        scroll.setAlignment(QtCore.Qt.AlignCenter)
+        scroll.setWidget(self.canvas)
+        bg = Color.actionBackgroundColor()
+        scroll.setStyleSheet(f"QScrollArea {{ background: {bg}; border: none; }}")
+        scroll.viewport().setAutoFillBackground(True)
+        scroll.viewport().setStyleSheet(f"background: {bg};")
+        splitter.addWidget(scroll)
+        self.inspector = OverlayInspector(scene)
+        self.inspector.setMinimumWidth(300)
+        self.inspector.setMaximumWidth(420)
+        splitter.addWidget(self.inspector)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setStretchFactor(2, 0)
+        splitter.setSizes([220, 760, 320])
+        root.addWidget(splitter, 1)
+        self.canvas.zoom_changed.connect(self._on_canvas_zoom)
+        self.scene.changed.connect(self._on_scene_ui)
+        if self._overlay_manager is not None:
+            try:
+                self._overlay_manager.visibility_changed.connect(self._refresh_overlay_button)
+            except Exception:
+                pass
+
+        hint = QtWidgets.QLabel(
+            "Drag widgets on the canvas. Shift+click multi-select. Hold Shift while resizing to keep aspect ratio. "
+            "Right-click for duplicate, delete, layer, and group. "
+            "Delete removes. Ctrl+D duplicates. Ctrl+G groups / Ctrl+Shift+G ungroups. Arrow keys nudge. Ctrl+wheel zooms. "
+            "With a widget selected, a palette click changes its type and keeps compatible settings. "
+            "Shape widgets can be rectangles, circles, triangles, diamonds, lines, or a freeform path. "
+            "Chroma/image: capture the GEX Overlay window in OBS (title includes the page name). On-screen: the HUD covers the chosen monitor. "
+            "Use the page tabs to keep independent overlays (HUD, MFD, …)."
+        )
+        hint.setWordWrap(True)
+        hint.setStyleSheet(f"color:{Color.normalColor()};")
+        root.addWidget(hint)
+
+        try:
+            el = gremlin.event_handler.EventListener()
+            el.profile_loaded.connect(self.refresh_profile_title)
+            el.profile_unloaded.connect(self.refresh_profile_title)
+        except Exception:
+            pass
+
+    @property
+    def inputCount(self) -> int:
+        return 0
+
+    @property
+    def inputWidgetCount(self) -> int:
+        return 0
+
+    def isLoaded(self) -> bool:
+        return True
+
+    def ensureLoaded(self):
+        if self._overlay_manager is not None:
+            self._overlay_manager._ensure_current_profile_scene()
+        self.refresh_profile_title()
+
+    def refresh(self, emit=True, force=False, **kwargs):
+        self.refresh_profile_title()
+
+    def refresh_ui(self):
+        self.refresh_profile_title()
+
+    def _on_zoom_slider(self, value: int):
+        if hasattr(self, "canvas"):
+            self.canvas.set_zoom(value / 100.0)
+        if hasattr(self, "_zoom_value"):
+            self._zoom_value.setText(f"{int(value)}%")
+
+    def _set_zoom_percent(self, percent: int):
+        if hasattr(self, "_zoom_slider"):
+            self._zoom_slider.setValue(int(percent))
+        else:
+            self._on_zoom_slider(int(percent))
+
+    def _on_canvas_zoom(self, zoom: float):
+        percent = int(round(float(zoom) * 100))
+        if hasattr(self, "_zoom_slider"):
+            with QtCore.QSignalBlocker(self._zoom_slider):
+                self._zoom_slider.setValue(percent)
+        if hasattr(self, "_zoom_value"):
+            self._zoom_value.setText(f"{percent}%")
+
+    def _toolbar(self) -> QtWidgets.QWidget:
+        bar = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(bar)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self._overlay_button = QtWidgets.QPushButton("Show overlay")
+        self._overlay_button.setToolTip("Show or hide the live window for the selected overlay page")
+        self._overlay_button.clicked.connect(lambda _=False: self._toggle_overlay())
+        self._interactive_box = QtWidgets.QCheckBox("Interactive")
+        self._interactive_box.setToolTip(
+            "On this page’s live overlay, touch or click widgets bound to vJoy or GEX states. "
+            "Physical bindings stay display-only. Empty space stays click-through."
+        )
+        self._interactive_box.setChecked(bool(self.scene.canvas.get("interactive")))
+        self._interactive_box.toggled.connect(self._set_interactive)
+        save = QtWidgets.QPushButton("Save layout")
+        save.setToolTip("Store this overlay with the current GEX profile")
+        save.clicked.connect(self._save)
+        load = QtWidgets.QPushButton("Load layout...")
+        load.clicked.connect(self._load)
+        undo = QtWidgets.QPushButton("Undo")
+        undo.clicked.connect(self.scene.undo)
+        redo = QtWidgets.QPushButton("Redo")
+        redo.clicked.connect(self.scene.redo)
+        save_template = QtWidgets.QPushButton("Save template")
+        save_template.setToolTip("Save the current widgets as a global template (not profile-specific)")
+        save_template.clicked.connect(lambda _=False: self._save_template())
+        for widget in (self._overlay_button, self._interactive_box, save, load, undo, redo, save_template):
+            layout.addWidget(widget)
+        layout.addStretch()
+        zoom_label = QtWidgets.QLabel("Zoom")
+        self._zoom_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self._zoom_slider.setRange(25, 400)
+        self._zoom_slider.setValue(100)
+        self._zoom_slider.setFixedWidth(140)
+        self._zoom_slider.setToolTip("Scale the designer canvas. Does not change the overlay resolution. Ctrl+wheel, Ctrl+0 reset.")
+        self._zoom_slider.valueChanged.connect(self._on_zoom_slider)
+        self._zoom_value = QtWidgets.QLabel("100%")
+        self._zoom_value.setMinimumWidth(44)
+        reset_zoom = QtWidgets.QPushButton("100%")
+        reset_zoom.setFixedWidth(48)
+        reset_zoom.setToolTip("Reset designer zoom to 100%")
+        reset_zoom.clicked.connect(lambda _=False: self._set_zoom_percent(100))
+        layout.addWidget(zoom_label)
+        layout.addWidget(self._zoom_slider)
+        layout.addWidget(self._zoom_value)
+        layout.addWidget(reset_zoom)
+        self._refresh_overlay_button()
+        return bar
+
+    def _page_bar(self) -> QtWidgets.QWidget:
+        self._page_tabs = QTabHeader()
+        self._page_tabs.setContentsMargins(0, 0, 0, 0)
+        self._page_tabs.setMovable(True)
+        self._page_tabs.setUsesScrollButtons(True)
+        self._page_tabs.setObjectName("overlay_pages")
+        self._page_tabs.setStyleSheet(Color.cssTab())
+        self._page_tabs.setToolTip("Each tab is a separate overlay. Double-click to rename. Right-click to add, duplicate, or delete. Drag to reorder.")
+        self._page_tabs.currentChanged.connect(self._on_page_tab_changed)
+        self._page_tabs.tabBarDoubleClicked.connect(self._rename_page_tab)
+        self._page_tabs.tabContextMenu.connect(self._page_tab_context)
+        self._page_tabs.tabMoveCompleted.connect(self._on_page_tab_moved)
+        add = gremlin.ui.ui_common.Buttons.getAddWidget(
+            label=None,
+            tooltip="Add overlay page",
+            callback=lambda _data=None: self._add_page(),
+        )
+        add.setFixedSize(24, 24)
+        row = gremlin.ui.ui_common.getHContainer([add, self._page_tabs], widget_only=True)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setMaximumHeight(30)
+        self._page_tabs_sig = None
+        self._refresh_page_tabs()
+        return row
+
+    def _on_scene_ui(self):
+        self._refresh_page_tabs()
+        self._refresh_interactive_box()
+        self._refresh_overlay_button()
+
+    def _refresh_page_tabs(self):
+        tabs = getattr(self, "_page_tabs", None)
+        if tabs is None:
+            return
+        if getattr(tabs, "moveInProgress", False):
+            return
+        sig = (self.scene.active_page_id, tuple((page["id"], page.get("name") or "Overlay") for page in self.scene.pages))
+        if getattr(self, "_page_tabs_sig", None) == sig:
+            return
+        self._page_tabs_sig = sig
+        with QtCore.QSignalBlocker(tabs):
+            while tabs.count():
+                tabs.removeTab(0)
+            current = 0
+            for index, page in enumerate(self.scene.pages):
+                tabs.addTab(str(page.get("name") or "Overlay"))
+                tabs.setTabData(index, page["id"])
+                if page["id"] == self.scene.active_page_id:
+                    current = index
+            if tabs.count():
+                tabs.setCurrentIndex(current)
+
+    def _on_page_tab_changed(self, index: int):
+        if index < 0:
+            return
+        page_id = self._page_tabs.tabData(index)
+        if page_id:
+            self.scene.set_active_page(str(page_id))
+
+    def _rename_page_tab(self, index: int):
+        if index < 0:
+            return
+        page_id = self._page_tabs.tabData(index)
+        page = self.scene.page_by_id(page_id)
+        if page is None:
+            return
+        name, ok = QtWidgets.QInputDialog.getText(self, "Rename overlay page", "Name:", text=str(page.get("name") or ""))
+        if ok:
+            self.scene.rename_page(name, page_id)
+
+    def _on_page_tab_moved(self, _from_index: int, _to_index: int):
+        tabs = getattr(self, "_page_tabs", None)
+        if tabs is None:
+            return
+        order = []
+        for index in range(tabs.count()):
+            page_id = tabs.tabData(index)
+            if page_id:
+                order.append(str(page_id))
+        if order:
+            self.scene.reorder_pages(order)
+
+    def _page_tab_context(self, index: int):
+        if index < 0:
+            return
+        page_id = self._page_tabs.tabData(index)
+        menu = QtWidgets.QMenu(self)
+        add = menu.addAction("Add page")
+        rename = menu.addAction("Rename")
+        duplicate = menu.addAction("Duplicate")
+        delete = menu.addAction("Delete")
+        delete.setEnabled(len(self.scene.pages) > 1)
+        chosen = menu.exec(QtGui.QCursor.pos())
+        if chosen is add:
+            self._add_page()
+        elif chosen is rename:
+            self._rename_page_tab(index)
+        elif chosen is duplicate:
+            self.scene.duplicate_page(page_id)
+        elif chosen is delete:
+            self._delete_page(page_id)
+
+    def _add_page(self):
+        self.scene.add_page()
+
+    def _delete_page(self, page_id):
+        if len(self.scene.pages) <= 1:
+            QtWidgets.QMessageBox.information(self, "OBS Overlay", "Keep at least one overlay page.")
+            return
+        page = self.scene.page_by_id(page_id)
+        name = (page or {}).get("name") or "this page"
+        confirm = QtWidgets.QMessageBox.question(
+            self,
+            "Delete overlay page",
+            f"Delete “{name}”? Widgets on this page are removed from the layout.",
+        )
+        if confirm == QtWidgets.QMessageBox.Yes:
+            self.scene.delete_page(page_id)
+
+    def _palette(self) -> QtWidgets.QWidget:
+        panel = QtWidgets.QWidget()
+        panel.setMinimumWidth(220)
+        panel.setMaximumWidth(280)
+        layout = QtWidgets.QVBoxLayout(panel)
+        for title, types in PALETTE_GROUPS:
+            layout.addWidget(QtWidgets.QLabel(title))
+            for widget_type in types:
+                btn = QtWidgets.QPushButton(WIDGET_TITLES.get(widget_type, widget_type))
+                btn.setToolTip(
+                    f"Add a {WIDGET_TITLES.get(widget_type, widget_type)}. "
+                    "If a widget is selected, change it to this type and keep compatible settings."
+                )
+                btn.clicked.connect(lambda _=False, t=widget_type: self._add_widget(t))
+                layout.addWidget(btn)
+        layout.addSpacing(12)
+        layout.addWidget(QtWidgets.QLabel("Templates"))
+        for name, tip, factory in TEMPLATES:
+            btn = TemplateButton(name, editable=False)
+            btn.setToolTip(tip)
+            btn.apply_requested.connect(lambda fn=factory, title=name: self._apply_template(title, fn))
+            layout.addWidget(btn)
+        layout.addWidget(QtWidgets.QLabel("Saved templates"))
+        self._user_templates_host = QtWidgets.QWidget()
+        self._user_templates_layout = QtWidgets.QVBoxLayout(self._user_templates_host)
+        self._user_templates_layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._user_templates_host)
+        self._refresh_user_templates()
+        layout.addStretch()
+        bg = Color.actionBackgroundColor()
+        panel.setStyleSheet(f"QWidget {{ background: {bg}; }}")
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        scroll.setWidget(panel)
+        scroll.setMinimumWidth(220)
+        scroll.setMaximumWidth(280)
+        return scroll
+
+    def _add_widget(self, widget_type: str):
+        if self.scene.convert_selected(widget_type):
+            self.canvas.setFocus()
+            return
+        size = DEFAULT_SIZES.get(widget_type, (80, 80))
+        if widget_type == "streamdeck":
+            size = self._streamdeck_add_size()
+        x, y = self._viewport_add_origin(int(size[0]), int(size[1]))
+        item = self.scene.add_widget(widget_type, x, y)
+        if widget_type == "streamdeck" and item:
+            item["w"] = int(size[0])
+            item["h"] = int(size[1])
+            self.scene._emit()
+        self.canvas.setFocus()
+
+    def _streamdeck_add_size(self) -> tuple[int, int]:
+        try:
+            from gremlin.ui.streamdeck_device import StreamDeckBridge
+            from .widgets import streamdeck_preferred_size
+
+            bridge = StreamDeckBridge()
+            device_id = bridge.resolve_overlay_device_id("")
+            info = bridge.devices.get(device_id, {}) if device_id else {}
+            return streamdeck_preferred_size((info or {}).get("type"))
+        except Exception:
+            return DEFAULT_SIZES.get("streamdeck", (320, 208))
+
+    def _viewport_add_origin(self, width: int, height: int) -> tuple[int, int]:
+        scroll = getattr(self, "_canvas_scroll", None)
+        canvas_w = max(1, int(self.scene.canvas.get("width") or 1280))
+        canvas_h = max(1, int(self.scene.canvas.get("height") or 720))
+        if scroll is not None:
+            viewport = scroll.viewport()
+            center = self.canvas.mapFrom(viewport, viewport.rect().center())
+            scene = self.canvas.map_to_scene(QtCore.QPointF(center))
+            x = int(scene.x() - width / 2)
+            y = int(scene.y() - height / 2)
+        else:
+            x = int(canvas_w / 2 - width / 2)
+            y = int(canvas_h / 2 - height / 2)
+        return max(0, min(canvas_w - width, x)), max(0, min(canvas_h - height, y))
+
+    def _apply_template(self, title: str, factory):
+        items = factory()
+        if not items:
+            if title.lower().startswith("blank"):
+                self.scene.clear_widgets()
+            return
+        self.scene.add_widgets(items)
+
+    def _refresh_user_templates(self):
+        layout = getattr(self, "_user_templates_layout", None)
+        if layout is None:
+            return
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+        entries = list_user_templates()
+        if not entries:
+            hint = QtWidgets.QLabel("None yet — use Save template.")
+            hint.setWordWrap(True)
+            layout.addWidget(hint)
+            return
+        for name, tip, factory, filename in entries:
+            btn = TemplateButton(name, editable=True)
+            btn.setToolTip(f"{tip}. Click to apply. Right-click to update with the current widgets or delete.")
+            btn.apply_requested.connect(lambda fn=factory, title=name: self._apply_template(title, fn))
+            btn.update_requested.connect(lambda fname=filename, title=name: self._update_template(fname, title))
+            btn.delete_requested.connect(lambda fname=filename, title=name: self._delete_template(fname, title))
+            layout.addWidget(btn)
+
+    def _update_template(self, filename: str, title: str):
+        if not self.scene.widgets:
+            QtWidgets.QMessageBox.information(self, "OBS Overlay", "Add widgets before updating a template.")
+            return
+        try:
+            update_user_template(filename, self.scene.widgets)
+        except Exception as err:
+            QtWidgets.QMessageBox.warning(self, "OBS Overlay", f"Could not update template:\n{err}")
+            return
+        self._refresh_user_templates()
+        QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), f"Updated {title}", self)
+
+    def _delete_template(self, filename: str, title: str):
+        try:
+            delete_user_template(filename)
+        except Exception as err:
+            QtWidgets.QMessageBox.warning(self, "OBS Overlay", f"Could not delete template:\n{err}")
+            return
+        self._refresh_user_templates()
+        QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), f"Deleted {title}", self)
+
+    def _save_template(self):
+        if not self.scene.widgets:
+            QtWidgets.QMessageBox.information(self, "OBS Overlay", "Add widgets before saving a template.")
+            return
+        name, ok = QtWidgets.QInputDialog.getText(self, "Save template", "Template name:")
+        if not ok or not str(name).strip():
+            return
+        try:
+            path = save_user_template(str(name).strip(), self.scene.widgets)
+        except Exception as err:
+            QtWidgets.QMessageBox.warning(self, "OBS Overlay", f"Could not save template:\n{err}")
+            return
+        self._refresh_user_templates()
+        QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), f"Saved {path}", self)
+
+    def _set_interactive(self, checked: bool):
+        if bool(self.scene.canvas.get("interactive")) == bool(checked):
+            return
+        self.scene.canvas["interactive"] = bool(checked)
+        self.scene._dirty = True
+        self.scene.changed.emit()
+
+    def _refresh_interactive_box(self):
+        box = getattr(self, "_interactive_box", None)
+        if box is None:
+            return
+        checked = is_interactive_overlay(self.scene.canvas)
+        if box.isChecked() != checked:
+            with QtCore.QSignalBlocker(box):
+                box.setChecked(checked)
+
+    def _toggle_overlay(self):
+        manager = self._overlay_manager
+        page_id = self.scene.active_page_id
+        if manager is not None and page_id:
+            if manager.page_is_visible(page_id):
+                manager.hide_overlay_page(page_id)
+            else:
+                manager.show_overlay(page_ids=[page_id])
+            self._refresh_overlay_button()
+            return
+        if callable(self._overlay_callback):
+            self._overlay_callback()
+        self._refresh_overlay_button()
+
+    def _refresh_overlay_button(self):
+        button = getattr(self, "_overlay_button", None)
+        if button is None:
+            return
+        page_id = self.scene.active_page_id
+        visible = bool(self._overlay_manager and page_id and self._overlay_manager.page_is_visible(page_id))
+        button.setText("Hide overlay" if visible else "Show overlay")
+
+    def refresh_profile_title(self):
+        self._title.setText(f"Overlay — {profile_display_name()}")
+        self._refresh_overlay_button()
+
+    def _save(self):
+        if self.scene.save():
+            QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), f"Saved overlay for {profile_display_name()}", self)
+        else:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "OBS Overlay",
+                "Save the GEX profile first so this overlay can be stored with it.",
+            )
+
+    def _load(self):
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Import overlay layout", "", "Overlay JSON (*.overlay.json *.json)")
+        if path:
+            self.scene.load(path)
+            self.refresh_profile_title()
+
+    def showEvent(self, event):
+        self.canvas.attach_bus()
+        self._refresh_overlay_button()
+        super().showEvent(event)
+
+    def hideEvent(self, event):
+        self.canvas.detach_bus()
+        if self.scene.dirty:
+            self.scene.save()
+        super().hideEvent(event)
+
+
+OverlayDesignerDialog = OverlayDesignerWidget

--- a/gremlin/ui/obs_overlay/inspector.py
+++ b/gremlin/ui/obs_overlay/inspector.py
@@ -17,6 +17,7 @@ from shiboken6 import Shiboken
 import gremlin.joystick_handling
 import gremlin.types
 import gremlin.ui.ui_common
+import gremlin.util
 from gremlin.input_types import InputType
 
 from .bindings import widget_needs_xy
@@ -311,6 +312,11 @@ class OverlayInspector(QtWidgets.QWidget):
 
     def rebuild(self):
         if not self._is_alive():
+            return
+        app = QtWidgets.QApplication.instance()
+        if app is not None and QtCore.QThread.currentThread() is not app.thread():
+            # Scene signals are psygnal (same-thread); bounce off worker threads.
+            gremlin.util.InvokeUiMethod(self.rebuild)
             return
         if self._building:
             self._rebuild_pending = True

--- a/gremlin/ui/obs_overlay/inspector.py
+++ b/gremlin/ui/obs_overlay/inspector.py
@@ -1,0 +1,1917 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import logging
+
+from PySide6 import QtCore, QtGui, QtWidgets
+from shiboken6 import Shiboken
+
+import gremlin.joystick_handling
+import gremlin.types
+import gremlin.ui.ui_common
+from gremlin.input_types import InputType
+
+from .bindings import widget_needs_xy
+from .model import (
+    DEFAULT_GUIDE_COLOR,
+    NO_CORNER_RADIUS_TYPES,
+    OverlayScene,
+    canonical_widget_type,
+    default_style,
+    is_onscreen_mode,
+    normalize_background_mode,
+    normalize_toggle_binding,
+)
+from .shapes import SHAPE_KIND_LABELS, default_shape_points, normalize_shape_kind
+from .overlay_window import apply_onscreen_geometry, list_overlay_screens, resolve_overlay_screen
+from .palettes import (
+    BUILTIN_IDS,
+    COLOR_KEYS,
+    add_palette,
+    delete_palette,
+    extract_colors,
+    list_builtin_palettes,
+    list_user_palettes,
+    palette_type,
+    update_palette,
+)
+from .widgets import effective_font_size, qcolor
+
+CANVAS_TOGGLE_ID = "__canvas_toggle__"
+syslog = logging.getLogger("system")
+
+
+class ColorButton(QtWidgets.QPushButton):
+    color_changed = QtCore.Signal(str)
+
+    def __init__(self, value="#ffffff", parent=None, preserve_transparent: bool = False):
+        super().__init__(parent)
+        self.setObjectName("overlayColorSwatch")
+        self._value = value or "#ffffff"
+        self._preserve_transparent = bool(preserve_transparent)
+        self.setFixedHeight(24)
+        self.setCursor(QtCore.Qt.PointingHandCursor)
+        self.clicked.connect(self._pick)
+        self._refresh()
+
+    def set_value(self, value: str):
+        self._value = value or "#ffffff"
+        self._refresh()
+
+    def value(self) -> str:
+        return self._value
+
+    def _refresh(self):
+        color = qcolor(self._value)
+        # Object-name selector so this does not leak onto QColorDialog buttons.
+        self.setStyleSheet(
+            f"#overlayColorSwatch {{ background:{color.name(QtGui.QColor.HexArgb)}; border:1px solid #444; border-radius:3px; }}"
+        )
+        self.setToolTip(self._value)
+
+    def _pick(self):
+        chosen = QtWidgets.QColorDialog.getColor(
+            qcolor(self._value),
+            self.window() or self.parentWidget() or self,
+            "Select color",
+            QtWidgets.QColorDialog.DontUseNativeDialog | QtWidgets.QColorDialog.ShowAlphaChannel,
+        )
+        if chosen.isValid():
+            previous = qcolor(self._value)
+            # Transparent defaults keep alpha at 0 in the picker; bump so fill/border actually show.
+            if not self._preserve_transparent and previous.alpha() == 0 and chosen.alpha() == 0:
+                chosen.setAlpha(255)
+            self._value = chosen.name(QtGui.QColor.HexArgb)
+            self._refresh()
+            self.color_changed.emit(self._value)
+
+
+class PaletteSwatch(QtWidgets.QPushButton):
+    """One saved color set, shown as a fill square (cross if the fill is transparent)."""
+
+    apply_requested = QtCore.Signal()
+    update_requested = QtCore.Signal()
+    delete_requested = QtCore.Signal()
+
+    def __init__(self, colors: dict, label: str, editable: bool = False, parent=None):
+        super().__init__(parent)
+        self._colors = colors or {}
+        self._editable = editable
+        self.setFixedSize(28, 28)
+        self.setCursor(QtCore.Qt.PointingHandCursor)
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setFlat(True)
+        self.setStyleSheet("QPushButton { border: none; background: transparent; padding: 0; }")
+        if editable:
+            self.setToolTip(f"{label}. Click to apply. Right-click to update with the current colors or delete.")
+            self.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
+        else:
+            self.setToolTip(f"{label}. Click to apply.")
+            self.setContextMenuPolicy(QtCore.Qt.NoContextMenu)
+        self.clicked.connect(lambda _=False: self.apply_requested.emit())
+
+    def paintEvent(self, event):
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.Antialiasing, False)
+        rect = self.rect().adjusted(2, 2, -3, -3)
+        fill = qcolor(self._colors.get("fill"), "#121826")
+        accent = qcolor(
+            self._colors.get("fill_on") or self._colors.get("indicator") or self._colors.get("fill_bar") or self._colors.get("border"),
+            "#888888",
+        )
+        outline = qcolor(self._colors.get("border") or self._colors.get("indicator"), "#555555")
+        if fill.alpha() <= 0:
+            painter.fillRect(rect, QtGui.QColor("#2a2a2a"))
+            painter.setPen(QtGui.QPen(accent if accent.alpha() > 0 else QtGui.QColor("#888888"), 2))
+            painter.drawLine(rect.topLeft() + QtCore.QPoint(1, 1), rect.bottomRight() - QtCore.QPoint(1, 1))
+            painter.drawLine(rect.topRight() + QtCore.QPoint(-1, 1), rect.bottomLeft() + QtCore.QPoint(1, -1))
+        else:
+            painter.fillRect(rect, fill)
+            if accent.alpha() > 0 and accent != fill:
+                corner = QtCore.QRect(rect.right() - 8, rect.bottom() - 8, 8, 8)
+                painter.fillRect(corner, accent)
+        painter.setPen(QtGui.QPen(outline if outline.alpha() > 0 else QtGui.QColor("#555555"), 1))
+        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.drawRect(rect)
+        painter.end()
+
+    def contextMenuEvent(self, event: QtGui.QContextMenuEvent):
+        if not self._editable:
+            return
+        menu = QtWidgets.QMenu(self)
+        update_action = menu.addAction("Update with current colors")
+        update_action.triggered.connect(lambda _=False: self.update_requested.emit())
+        delete_action = menu.addAction("Delete palette")
+        delete_action.triggered.connect(lambda _=False: self.delete_requested.emit())
+        menu.exec(event.globalPos())
+
+
+class OverlayInspector(QtWidgets.QWidget):
+    """Property panel for canvas + selected widget."""
+
+    def __init__(self, scene: OverlayScene, parent=None):
+        super().__init__(parent)
+        self.scene = scene
+        self._building = False
+        self._edit_ids: list[str] = []
+        self._multi = False
+        self._live_fields: list = []
+        self._rebuild_pending = False
+        self._last_rebuild_ids: list[str] = []
+        self._pending_scroll = (0, 0)
+        self._scroll_restore_tries = 0
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        self._host = QtWidgets.QWidget()
+        self._form = QtWidgets.QVBoxLayout(self._host)
+        self._form.setContentsMargins(0, 0, 0, 0)
+        scroll.setWidget(self._host)
+        layout.addWidget(scroll)
+        self._scroll = scroll
+        self.scene.selection_changed.connect(self.rebuild)
+        self.scene.changed.connect(self._maybe_rebuild)
+        self.destroyed.connect(self._detach_scene)
+        self._canvas_sig = None
+        try:
+            from gremlin.ui.streamdeck_device import StreamDeckBridge
+
+            StreamDeckBridge().devices_changed.connect(self._on_streamdeck_devices_changed)
+        except Exception:
+            pass
+        self.rebuild()
+
+    def _detach_scene(self, *_args):
+        try:
+            self.scene.selection_changed.disconnect(self.rebuild)
+        except Exception:
+            pass
+        try:
+            self.scene.changed.disconnect(self._maybe_rebuild)
+        except Exception:
+            pass
+        try:
+            from gremlin.ui.streamdeck_device import StreamDeckBridge
+
+            StreamDeckBridge().devices_changed.disconnect(self._on_streamdeck_devices_changed)
+        except Exception:
+            pass
+        self._scroll = None
+        self._form = None
+        self._host = None
+
+    def _is_alive(self) -> bool:
+        try:
+            return Shiboken.isValid(self)
+        except Exception:
+            return False
+
+    def _scroll_area(self):
+        if not self._is_alive():
+            return None
+        scroll = getattr(self, "_scroll", None)
+        try:
+            if scroll is None or not Shiboken.isValid(scroll):
+                return None
+        except Exception:
+            return None
+        return scroll
+
+    def _on_streamdeck_devices_changed(self):
+        if not self._is_alive():
+            return
+        items = self.scene.selected_widgets()
+        if any(canonical_widget_type(item.get("type")) == "streamdeck" for item in items):
+            self._schedule_rebuild()
+
+    def _canvas_signature(self):
+        canvas = self.scene.canvas
+        page = self.scene.active_page() or {}
+        return (
+            self.scene.active_page_id,
+            page.get("name"),
+            page.get("visible"),
+            page.get("window_x"),
+            page.get("window_y"),
+            canvas.get("width"),
+            canvas.get("height"),
+            canvas.get("background_mode"),
+            canvas.get("monitor_index"),
+            canvas.get("monitor_name"),
+            canvas.get("interactive"),
+        )
+
+    def _maybe_rebuild(self):
+        if not self._is_alive():
+            return
+        if self._building:
+            self._rebuild_pending = True
+            return
+        if self._rebuild_pending:
+            return
+        sig = self._canvas_signature()
+        if sig != self._canvas_sig:
+            self._schedule_rebuild()
+            return
+        self._refresh_live_fields()
+
+    def _schedule_rebuild(self):
+        if self._rebuild_pending:
+            return
+        self._rebuild_pending = True
+        QtCore.QTimer.singleShot(0, self._run_scheduled_rebuild)
+
+    def _run_scheduled_rebuild(self):
+        self._rebuild_pending = False
+        if not self._is_alive():
+            return
+        try:
+            self.rebuild()
+        except RuntimeError:
+            return
+
+    def _refresh_live_fields(self):
+        for fn in list(self._live_fields):
+            try:
+                fn()
+            except RuntimeError:
+                continue
+
+    def _clear(self):
+        layout = self._form
+        if layout is None:
+            return
+        try:
+            while layout.count():
+                item = layout.takeAt(0)
+                widget = item.widget()
+                if widget is not None:
+                    # Hide first. setParent(None) would make a visible top-level
+                    # window (title = application name) for a frame on page switch.
+                    widget.hide()
+                    widget.deleteLater()
+        except RuntimeError:
+            return
+
+    def _section(self, title: str) -> QtWidgets.QFormLayout:
+        box = QtWidgets.QGroupBox(title)
+        form = QtWidgets.QFormLayout(box)
+        form.setLabelAlignment(QtCore.Qt.AlignRight)
+        self._form.addWidget(box)
+        return form
+
+    def rebuild(self):
+        if not self._is_alive():
+            return
+        if self._building:
+            self._rebuild_pending = True
+            return
+        self._building = True
+        self._rebuild_pending = False
+        self._live_fields = []
+        built_ids = None
+        previous_ids = list(self._last_rebuild_ids)
+        saved_v = 0
+        saved_h = 0
+        scroll = self._scroll_area()
+        if scroll is not None:
+            try:
+                saved_v = scroll.verticalScrollBar().value()
+                saved_h = scroll.horizontalScrollBar().value()
+            except RuntimeError:
+                saved_v = 0
+                saved_h = 0
+        try:
+            self._canvas_sig = self._canvas_signature()
+            self._clear()
+            items = self.scene.selected_widgets()
+            self._edit_ids = [item["id"] for item in items]
+            self._multi = len(items) > 1
+            if not items:
+                # Canvas / toggle overlay only when nothing is selected.
+                self._build_canvas()
+                hint = QtWidgets.QLabel("Select a widget on the canvas, or add one from the palette.")
+                hint.setWordWrap(True)
+                self._form.addWidget(hint)
+                self._form.addStretch()
+            else:
+                types = {canonical_widget_type(item.get("type")) for item in items}
+                if self._multi and len(types) > 1:
+                    self._build_mixed(items)
+                else:
+                    self._build_widget(items[0])
+                self._form.addStretch()
+            built_ids = list(self._edit_ids)
+            self._last_rebuild_ids = built_ids
+            keep_scroll = bool(built_ids) and built_ids == previous_ids
+            self._pending_scroll = (saved_h, saved_v) if keep_scroll else (0, 0)
+            self._scroll_restore_tries = 0
+            QtCore.QTimer.singleShot(0, self._restore_inspector_scroll)
+        except RuntimeError:
+            return
+        except Exception:
+            syslog.exception("OBS OVERLAY: inspector rebuild failed")
+        finally:
+            self._building = False
+        if not self._is_alive():
+            return
+        current_ids = [item["id"] for item in self.scene.selected_widgets()]
+        if self._rebuild_pending or (built_ids is not None and current_ids != built_ids):
+            self._rebuild_pending = False
+            QtCore.QTimer.singleShot(0, self.rebuild)
+
+    def _restore_inspector_scroll(self):
+        scroll = self._scroll_area()
+        if scroll is None:
+            return
+        try:
+            hx, vy = self._pending_scroll
+            hbar = scroll.horizontalScrollBar()
+            vbar = scroll.verticalScrollBar()
+            if ((vy > vbar.maximum()) or (hx > hbar.maximum())) and self._scroll_restore_tries < 3:
+                self._scroll_restore_tries += 1
+                QtCore.QTimer.singleShot(0, self._restore_inspector_scroll)
+                return
+            hbar.setValue(min(max(0, int(hx)), hbar.maximum()))
+            vbar.setValue(min(max(0, int(vy)), vbar.maximum()))
+        except RuntimeError:
+            return
+
+    def _build_canvas(self):
+        form = self._section("Canvas")
+        canvas = self.scene.canvas
+        page = self.scene.active_page() or {}
+        onscreen = is_onscreen_mode(canvas)
+
+        name = QtWidgets.QLineEdit(str(page.get("name") or ""))
+        name.setToolTip("Name of this overlay page. Shown on the designer tab and in the live window title.")
+        name.editingFinished.connect(lambda edit=name: self._on_page_name(edit.text()))
+        form.addRow("Name", name)
+
+        visible = QtWidgets.QCheckBox()
+        visible.setChecked(bool(page.get("visible", True)))
+        visible.setToolTip("When off, this page’s live window is closed. Show overlay still only opens the selected page.")
+        visible.toggled.connect(lambda v: self.scene.set_page_visible(bool(v)))
+        form.addRow("Visible", visible)
+
+        start = QtWidgets.QCheckBox()
+        start.setChecked(bool(canvas.get("show_on_profile_start")))
+        start.toggled.connect(lambda v: self._set_canvas("show_on_profile_start", bool(v)))
+        form.addRow("Show at profile start", start)
+
+        interactive = QtWidgets.QCheckBox()
+        interactive.setChecked(bool(canvas.get("interactive")))
+        interactive.setToolTip(
+            "On this page’s live overlay, touch or click widgets bound to vJoy or GEX states. "
+            "Empty space stays click-through. Physical bindings stay display-only."
+        )
+        interactive.toggled.connect(lambda v: self._set_canvas("interactive", bool(v)))
+        form.addRow("Interactive", interactive)
+        touch_hint = QtWidgets.QLabel(
+            "vJoy buttons are held while pressed. A state button tap inverts the state. Sticks and hats return to center on lift; faders keep their value."
+        )
+        touch_hint.setWordWrap(True)
+        form.addRow(touch_hint)
+
+        mode = QtWidgets.QComboBox()
+        labels = [("chroma", "chroma"), ("image", "image"), ("onscreen", "on-screen")]
+        for stored, label in labels:
+            mode.addItem(label, stored)
+        current = normalize_background_mode(canvas.get("background_mode"))
+        mode.setCurrentIndex(next((i for i, (stored, _) in enumerate(labels) if stored == current), 0))
+        mode.currentIndexChanged.connect(lambda _i, box=mode: self._on_background_mode(box.currentData()))
+        form.addRow("Background", mode)
+
+        if onscreen:
+            screens = list_overlay_screens()
+            monitor = QtWidgets.QComboBox()
+            selected = resolve_overlay_screen(canvas)
+            selected_index = selected["index"] if selected else 0
+            for screen in screens:
+                monitor.addItem(screen["label"], screen["index"])
+            if screens:
+                pos = monitor.findData(selected_index)
+                if pos >= 0:
+                    monitor.setCurrentIndex(pos)
+            monitor.currentIndexChanged.connect(lambda _i, box=monitor: self._on_monitor(box.currentData()))
+            form.addRow("Monitor", monitor)
+            if bool(canvas.get("interactive")):
+                hint = QtWidgets.QLabel("Canvas size follows this monitor. Interactive is on: widgets capture touch; empty space passes through to the screen behind.")
+            else:
+                hint = QtWidgets.QLabel("Canvas size follows this monitor. The overlay is a transparent, click-through HUD.")
+            hint.setWordWrap(True)
+            form.addRow(hint)
+        else:
+            chroma = ColorButton(canvas.get("chroma_color") or "#00FF00", preserve_transparent=True)
+            chroma.color_changed.connect(lambda v: self._set_canvas("chroma_color", v))
+            form.addRow("Chroma color", chroma)
+            chroma_hint = QtWidgets.QLabel(
+                "Alpha 0 makes the overlay see-through to the desktop. Windows needs a frameless window for that — use the drag bar to move it. OBS chroma key still needs an opaque color."
+            )
+            chroma_hint.setWordWrap(True)
+            form.addRow(chroma_hint)
+
+            path_row = QtWidgets.QWidget()
+            path_layout = QtWidgets.QHBoxLayout(path_row)
+            path_layout.setContentsMargins(0, 0, 0, 0)
+            path_edit = QtWidgets.QLineEdit(canvas.get("image_path") or "")
+            browse = QtWidgets.QPushButton("...")
+            browse.setFixedWidth(28)
+
+            def _browse():
+                fname, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Background image", path_edit.text(), "Images (*.png *.jpg *.jpeg *.bmp *.webp)")
+                if fname:
+                    path_edit.setText(fname)
+                    self._set_canvas("image_path", fname)
+
+            browse.clicked.connect(_browse)
+            path_edit.editingFinished.connect(lambda: self._set_canvas("image_path", path_edit.text()))
+            path_layout.addWidget(path_edit)
+            path_layout.addWidget(browse)
+            form.addRow("Image", path_row)
+
+        width = QtWidgets.QSpinBox()
+        width.setRange(160, 7680)
+        width.setValue(int(canvas.get("width") or 1280))
+        height = QtWidgets.QSpinBox()
+        height.setRange(120, 4320)
+        height.setValue(int(canvas.get("height") or 720))
+        width.setEnabled(not onscreen)
+        height.setEnabled(not onscreen)
+        if not onscreen:
+            width.valueChanged.connect(lambda v: self._set_canvas("width", int(v)))
+            height.valueChanged.connect(lambda v: self._set_canvas("height", int(v)))
+        form.addRow("Width", width)
+        form.addRow("Height", height)
+
+        grid = QtWidgets.QSpinBox()
+        grid.setRange(1, 64)
+        grid.setValue(int(canvas.get("grid_size") or 8))
+        grid.valueChanged.connect(lambda v: self._set_canvas("grid_size", int(v)))
+        form.addRow("Grid size", grid)
+
+        snap = QtWidgets.QCheckBox()
+        snap.setChecked(bool(canvas.get("snap_to_grid", True)))
+        snap.toggled.connect(lambda v: self._set_canvas("snap_to_grid", v))
+        form.addRow("Snap to grid", snap)
+        self._build_guides(form, canvas)
+
+        if not onscreen:
+            top = QtWidgets.QCheckBox()
+            top.setChecked(bool(canvas.get("always_on_top")))
+            top.toggled.connect(lambda v: self._set_canvas("always_on_top", v))
+            form.addRow("Always on top", top)
+
+            frameless = QtWidgets.QCheckBox()
+            frameless.setChecked(bool(canvas.get("frameless")))
+            frameless.toggled.connect(lambda v: self._set_canvas("frameless", v))
+            form.addRow("Frameless", frameless)
+
+            drag = QtWidgets.QCheckBox()
+            drag.setChecked(bool(canvas.get("show_drag_bar", True)))
+            drag.toggled.connect(lambda v: self._set_canvas("show_drag_bar", v))
+            form.addRow("Overlay drag bar", drag)
+
+        reset = QtWidgets.QPushButton("Reset position")
+        if onscreen:
+            reset.setToolTip("Use the primary monitor if the saved display is gone.")
+        else:
+            reset.setToolTip("Clear the saved window position and center this overlay. Also used if the saved monitor is gone.")
+        reset.clicked.connect(lambda _=False: self._reset_page_position())
+        form.addRow(reset)
+        self._build_toggle_binding()
+
+    def _on_background_mode(self, stored: str):
+        if self._building:
+            return
+        stored = normalize_background_mode(stored)
+        previous = normalize_background_mode(self.scene.canvas.get("background_mode"))
+        if stored == previous:
+            return
+        self._building = True
+        try:
+            if stored == "onscreen" and previous != "onscreen":
+                self.scene.canvas["capture_width"] = int(self.scene.canvas.get("width") or 1280)
+                self.scene.canvas["capture_height"] = int(self.scene.canvas.get("height") or 720)
+                self.scene.canvas["background_mode"] = stored
+                if not apply_onscreen_geometry(self.scene):
+                    self.scene._dirty = True
+                    self.scene.changed.emit()
+            elif stored != "onscreen" and previous == "onscreen":
+                self.scene.canvas["background_mode"] = stored
+                restore_w = int(self.scene.canvas.get("capture_width") or 1280)
+                restore_h = int(self.scene.canvas.get("capture_height") or 720)
+                self.scene.canvas["width"] = restore_w
+                self.scene.canvas["height"] = restore_h
+                self.scene._dirty = True
+                self.scene.changed.emit()
+            else:
+                self.scene.canvas["background_mode"] = stored
+                self.scene._dirty = True
+                self.scene.changed.emit()
+        finally:
+            self._building = False
+        self._schedule_rebuild()
+
+    def _on_monitor(self, index):
+        if self._building or index is None:
+            return
+        self._building = True
+        try:
+            screens = list_overlay_screens()
+            chosen = next((screen for screen in screens if screen["index"] == int(index)), None)
+            self.scene.canvas["monitor_index"] = int(index)
+            if chosen:
+                self.scene.canvas["monitor_name"] = chosen["name"]
+            apply_onscreen_geometry(self.scene, monitor_index=int(index))
+        finally:
+            self._building = False
+        self._schedule_rebuild()
+
+    def _set_canvas(self, key, value):
+        if self.scene.canvas.get(key) == value:
+            return
+        self.scene.canvas[key] = value
+        self.scene._dirty = True
+        self.scene.changed.emit()
+
+    def _on_page_name(self, name: str):
+        if self._building:
+            return
+        self.scene.rename_page(name)
+
+    def _reset_page_position(self):
+        if self._building:
+            return
+        self.scene.reset_page_position()
+        if is_onscreen_mode(self.scene.canvas):
+            apply_onscreen_geometry(self.scene)
+
+    def _bind_live(self, widget, getter):
+        def _sync(w=widget, get=getter):
+            try:
+                value = get()
+            except RuntimeError:
+                return
+            w.blockSignals(True)
+            w.setValue(value)
+            w.blockSignals(False)
+
+        self._live_fields.append(_sync)
+
+    def _build_guides(self, form, canvas: dict):
+        buttons = QtWidgets.QWidget()
+        row = QtWidgets.QHBoxLayout(buttons)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(6)
+        add_v = QtWidgets.QPushButton("Add vertical")
+        add_v.setToolTip("Add a vertical guide. Widgets snap left, center, or right to it.")
+        add_v.clicked.connect(lambda _=False: self._add_guide("v"))
+        add_h = QtWidgets.QPushButton("Add horizontal")
+        add_h.setToolTip("Add a horizontal guide. Widgets snap top, center, or bottom to it.")
+        add_h.clicked.connect(lambda _=False: self._add_guide("h"))
+        row.addWidget(add_v)
+        row.addWidget(add_h)
+        row.addStretch()
+        form.addRow("Guides", buttons)
+        hint = QtWidgets.QLabel("Drag a guide on the canvas, or enter a percent of width (vertical) or height (horizontal).")
+        hint.setWordWrap(True)
+        form.addRow(hint)
+        for guide in canvas.get("guides") or []:
+            form.addRow("", self._guide_row(guide))
+
+    def _guide_row(self, guide: dict) -> QtWidgets.QWidget:
+        axis = "H" if guide.get("axis") == "h" else "V"
+        gid = guide.get("id")
+        percent = max(0.0, min(100.0, float(guide.get("position") or 0) * 100.0))
+        row = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        axis_label = QtWidgets.QLabel(axis)
+        axis_label.setFixedWidth(14)
+        slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        slider.setRange(0, 1000)
+        slider.setValue(int(round(percent * 10)))
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setRange(0.0, 100.0)
+        spin.setDecimals(1)
+        spin.setSuffix(" %")
+        spin.setValue(percent)
+        spin.setMaximumWidth(84)
+        color = ColorButton(guide.get("color") or DEFAULT_GUIDE_COLOR)
+        color.setFixedWidth(36)
+        delete = QtWidgets.QPushButton("×")
+        delete.setFixedWidth(24)
+        delete.setToolTip("Remove this guide")
+
+        def _from_slider(v, box=spin, ident=gid):
+            pct = v / 10.0
+            box.blockSignals(True)
+            box.setValue(pct)
+            box.blockSignals(False)
+            self.scene.update_guide(ident, position=pct / 100.0)
+
+        def _from_spin(v, bar=slider, ident=gid):
+            bar.blockSignals(True)
+            bar.setValue(int(round(float(v) * 10)))
+            bar.blockSignals(False)
+            self.scene.update_guide(ident, position=float(v) / 100.0)
+
+        slider.valueChanged.connect(_from_slider)
+        spin.valueChanged.connect(_from_spin)
+        color.color_changed.connect(lambda v, ident=gid: self.scene.update_guide(ident, color=v))
+        delete.clicked.connect(lambda _=False, ident=gid: self._remove_guide(ident))
+        self._bind_live(spin, lambda ident=gid: self._guide_percent(ident))
+        self._bind_live(slider, lambda ident=gid: int(round(self._guide_percent(ident) * 10)))
+        layout.addWidget(axis_label)
+        layout.addWidget(slider, 1)
+        layout.addWidget(spin)
+        layout.addWidget(color)
+        layout.addWidget(delete)
+        return row
+
+    def _guide_percent(self, guide_id: str) -> float:
+        guide = self.scene.guide_by_id(guide_id)
+        if not guide:
+            return 0.0
+        return max(0.0, min(100.0, float(guide.get("position") or 0) * 100.0))
+
+    def _add_guide(self, axis: str):
+        if self._building:
+            return
+        self.scene.add_guide(axis)
+        self.rebuild()
+
+    def _remove_guide(self, guide_id: str):
+        if self._building:
+            return
+        self.scene.remove_guide(guide_id)
+        self.rebuild()
+
+    def _build_widget(self, item: dict):
+        form = self._section("Geometry")
+        if self._multi:
+            types = sorted({(w.get("type") or "").replace("_", " ") for w in self.scene.selected_widgets()})
+            form.addRow("Selection", QtWidgets.QLabel(f"{len(self._edit_ids)} grouped widgets"))
+            form.addRow("Types", QtWidgets.QLabel(", ".join(types)))
+        else:
+            type_label = QtWidgets.QLabel(item.get("type", "").replace("_", " "))
+            form.addRow("Type", type_label)
+            canvas_w = max(1, int(self.scene.canvas.get("width") or 1280))
+            canvas_h = max(1, int(self.scene.canvas.get("height") or 720))
+            self._slider_int(
+                form,
+                "X",
+                int(item.get("x") or 0),
+                0,
+                canvas_w,
+                lambda v, wid=item["id"]: self._update(wid, x=int(v)),
+            )
+            self._slider_int(
+                form,
+                "Y",
+                int(item.get("y") or 0),
+                0,
+                canvas_h,
+                lambda v, wid=item["id"]: self._update(wid, y=int(v)),
+            )
+        for key, lo, hi in (("w", 8, 4000), ("h", 8, 4000), ("z", -100, 100)):
+            spin = QtWidgets.QSpinBox()
+            spin.setRange(lo, hi)
+            spin.setValue(int(self._common_field(lambda w: int(w.get(key) or 0), int(item.get(key) or 0))))
+            spin.valueChanged.connect(lambda v, k=key, wid=item["id"]: self._update(wid, **{k: int(v)}))
+            form.addRow(key.upper(), spin)
+
+        vis = QtWidgets.QCheckBox()
+        self._set_bool_widget(vis, [bool(w.get("visible", True)) for w in self.scene.selected_widgets()] or [bool(item.get("visible", True))])
+        vis.stateChanged.connect(lambda _s, wid=item["id"], box=vis: self._on_bool(box, wid, field="visible"))
+        form.addRow("Visible", vis)
+        self._style_bool(
+            form,
+            item,
+            "auto_scale_font",
+            "Scale font with size",
+            tooltip="Keep the same relative font size when this widget is resized.",
+        )
+
+        label_form = self._section("Label")
+        if not self._multi:
+            label = QtWidgets.QLineEdit(item.get("label") or "")
+            label.editingFinished.connect(lambda wid=item["id"], w=label: self._update(wid, label=w.text()))
+            label_form.addRow("Text", label)
+        self._style_bool(label_form, item, "show_label", "Show label")
+        self._style_font(label_form, item)
+        self._style_color(label_form, item, "font_color", "Font color")
+        self._slider_int(
+            label_form,
+            "Label offset X",
+            int(item["style"].get("label_offset_x") or 0),
+            -400,
+            400,
+            lambda v, wid=item["id"]: self._style(wid, label_offset_x=int(v)),
+        )
+        self._slider_int(
+            label_form,
+            "Label offset Y",
+            int(item["style"].get("label_offset_y") or 0),
+            -400,
+            400,
+            lambda v, wid=item["id"]: self._style(wid, label_offset_y=int(v)),
+        )
+        widget_type = canonical_widget_type(item.get("type"))
+        if widget_type == "label":
+            self._style_color(label_form, item, "fill", "Fill")
+            self._style_color(label_form, item, "border", "Border")
+            self._style_float(label_form, item, "border_width", "Border width", 0, 20)
+            self._style_float(label_form, item, "corner_radius", "Corner radius", 0, 200)
+
+        look = self._section("Appearance")
+        self._build_palettes(look, item)
+        self._opacity_slider(look, item)
+        if widget_type == "button":
+            shape = QtWidgets.QComboBox()
+            shape.addItems(["rounded", "rect", "circle", "pill"])
+            shape.setCurrentText(item["style"].get("shape") or "rounded")
+            shape.currentTextChanged.connect(lambda v, wid=item["id"]: self._style(wid, shape=v))
+            look.addRow("Shape", shape)
+            self._style_color(look, item, "fill", "Off fill")
+            self._style_color(look, item, "fill_on", "On fill")
+        elif widget_type == "axis_bar":
+            self._orientation_combo(look, item)
+            self._style_color(look, item, "fill", "Fill")
+            self._style_color(look, item, "indicator", "Dot")
+            self._style_float(look, item, "indicator_size", "Dot size", 2, 80)
+            self._indicator_shape(look, item)
+            self._style_bool(look, item, "show_dot_shadow", "Dot shadow")
+            self._style_bool(look, item, "show_dot_crosshair", "Lines through dot")
+            self._grid_appearance(look, item)
+            self._crosshair_appearance(look, item)
+        elif widget_type == "axis_radio":
+            self._orientation_combo(look, item, default="horizontal")
+            steps = QtWidgets.QSpinBox()
+            steps.setRange(2, 32)
+            steps.setValue(int(item["style"].get("radio_steps") or 5))
+            steps.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, radio_steps=int(v)))
+            look.addRow("Steps", steps)
+            self._style_color(look, item, "fill", "Off fill")
+            self._style_color(look, item, "fill_on", "On fill")
+            self._style_bool(look, item, "invert_display", "Invert")
+        elif widget_type == "axis_fader":
+            self._orientation_combo(look, item)
+            self._style_color(look, item, "fill", "Track")
+            self._style_color(look, item, "fill_bar", "Fill")
+            self._style_color(look, item, "fill_on", "Thumb")
+            self._style_color(look, item, "grid", "Rungs")
+            steps = QtWidgets.QSpinBox()
+            steps.setRange(3, 32)
+            steps.setValue(int(item["style"].get("radio_steps") or 8))
+            steps.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, radio_steps=int(v)))
+            look.addRow("Rungs", steps)
+            thumb = QtWidgets.QDoubleSpinBox()
+            thumb.setRange(0, 80)
+            thumb.setSingleStep(1)
+            thumb.setSpecialValueText("One rung")
+            thumb.setValue(float(item["style"].get("indicator_size") or 0))
+            thumb.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, indicator_size=float(v)))
+            look.addRow("Thumb size", thumb)
+            self._style_bool(look, item, "invert_display", "Invert")
+        elif widget_type in ("axis_radial", "axis_dial"):
+            self._style_color(look, item, "track", "Track")
+            self._style_color(look, item, "fill_bar", "Arc")
+            self._style_color(look, item, "grid", "Ticks")
+            self._style_float(look, item, "needle_width", "Arc width", 4, 40)
+            ticks = QtWidgets.QSpinBox()
+            ticks.setRange(2, 48)
+            ticks.setValue(int(item["style"].get("radio_steps") or 11))
+            ticks.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, radio_steps=int(v)))
+            look.addRow("Ticks", ticks)
+            self._style_bool(look, item, "invert_display", "Invert")
+        elif widget_type == "axis_encoder":
+            self._style_color(look, item, "fill", "Off fill")
+            self._style_color(look, item, "fill_on", "On fill")
+            self._style_color(look, item, "grid", "Ticks")
+            ring = QtWidgets.QDoubleSpinBox()
+            ring.setRange(0, 80)
+            ring.setSingleStep(1)
+            ring.setSpecialValueText("Auto")
+            ring.setValue(float(item["style"].get("needle_width") or 0))
+            ring.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, needle_width=float(v)))
+            look.addRow("Ring thickness", ring)
+            ticks = QtWidgets.QSpinBox()
+            ticks.setRange(4, 48)
+            ticks.setValue(int(item["style"].get("radio_steps") or 16))
+            ticks.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, radio_steps=int(v)))
+            look.addRow("Steps", ticks)
+            self._style_bool(look, item, "invert_display", "Invert")
+        elif widget_type in ("axis_stick_square", "axis_stick_circle", "axis_crosshair", "hat"):
+            self._style_color(look, item, "fill", "Fill")
+            self._style_color(look, item, "indicator", "Dot")
+            self._style_float(look, item, "indicator_size", "Dot size", 2, 80)
+            if widget_type == "hat":
+                positions = QtWidgets.QComboBox()
+                positions.addItem("4-position", 4)
+                positions.addItem("8-position", 8)
+                current = 8 if int(item["style"].get("hat_positions") or 4) >= 8 else 4
+                positions.setCurrentIndex(1 if current == 8 else 0)
+                positions.currentIndexChanged.connect(
+                    lambda _i, box=positions, wid=item["id"]: self._style(wid, hat_positions=int(box.currentData() or 4))
+                )
+                look.addRow("Positions", positions)
+                self._crosshair_appearance(look, item, show_toggle=False)
+            else:
+                self._indicator_shape(look, item)
+                self._style_bool(look, item, "show_dot_shadow", "Dot shadow")
+                self._style_bool(look, item, "show_dot_crosshair", "Lines through dot")
+                if widget_type in ("axis_stick_circle", "axis_crosshair"):
+                    self._angle_step_combo(look, item)
+                    rings = QtWidgets.QSpinBox()
+                    rings.setRange(1, 8)
+                    rings.setValue(int(item["style"].get("ring_count") or 3))
+                    rings.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, ring_count=int(v)))
+                    look.addRow("Rings", rings)
+                self._grid_appearance(look, item)
+                self._crosshair_appearance(look, item)
+        elif widget_type in ("shape", "panel"):
+            self._shape_appearance(look, item)
+        elif widget_type == "image":
+            self._image_appearance(look, item)
+        elif widget_type == "streamdeck":
+            self._streamdeck_appearance(look, item)
+        elif widget_type != "label":
+            self._style_color(look, item, "fill", "Fill")
+
+        self._append_shared_appearance(look, item, widget_type)
+
+    def _build_mixed(self, items: list[dict]):
+        types = {item.get("type") for item in items}
+        item = items[0]
+        form = self._section("Geometry")
+        form.addRow("Selection", QtWidgets.QLabel(f"{len(items)} grouped widgets"))
+        form.addRow("Types", QtWidgets.QLabel(", ".join(sorted((t or "").replace("_", " ") for t in types))))
+        for key, lo, hi in (("w", 8, 4000), ("h", 8, 4000), ("z", -100, 100)):
+            spin = QtWidgets.QSpinBox()
+            spin.setRange(lo, hi)
+            spin.setValue(int(self._common_field(lambda w, k=key: int(w.get(k) or 0), int(item.get(key) or 0))))
+            spin.valueChanged.connect(lambda v, k=key, wid=item["id"]: self._update(wid, **{k: int(v)}))
+            form.addRow(key.upper(), spin)
+        vis = QtWidgets.QCheckBox()
+        self._set_bool_widget(vis, [bool(w.get("visible", True)) for w in items])
+        vis.stateChanged.connect(lambda _s, wid=item["id"], box=vis: self._on_bool(box, wid, field="visible"))
+        form.addRow("Visible", vis)
+        self._style_bool(
+            form,
+            item,
+            "auto_scale_font",
+            "Scale font with size",
+            tooltip="Keep the same relative font size when this widget is resized.",
+        )
+
+        label_form = self._section("Label")
+        self._style_bool(label_form, item, "show_label", "Show label")
+        self._style_font(label_form, item)
+        self._style_color(label_form, item, "font_color", "Font color")
+        self._slider_int(
+            label_form,
+            "Label offset X",
+            int(item["style"].get("label_offset_x") or 0),
+            -400,
+            400,
+            lambda v, wid=item["id"]: self._style(wid, label_offset_x=int(v)),
+        )
+        self._slider_int(
+            label_form,
+            "Label offset Y",
+            int(item["style"].get("label_offset_y") or 0),
+            -400,
+            400,
+            lambda v, wid=item["id"]: self._style(wid, label_offset_y=int(v)),
+        )
+
+        look = self._section("Appearance")
+        if len(types) == 1:
+            self._build_palettes(look, item)
+        self._opacity_slider(look, item)
+        self._style_color(look, item, "fill", "Fill")
+        if types <= {"button"}:
+            self._style_color(look, item, "fill_on", "On fill")
+        if types <= {"axis_bar", "axis_radio", "axis_fader"}:
+            self._orientation_combo(look, item)
+        if types <= {"axis_stick_circle", "axis_crosshair"}:
+            self._angle_step_combo(look, item)
+        if types <= {"axis_bar", "axis_stick_square", "axis_stick_circle", "axis_crosshair"}:
+            self._style_color(look, item, "indicator", "Dot")
+            self._indicator_shape(look, item)
+            self._style_bool(look, item, "show_dot_shadow", "Dot shadow")
+            self._style_bool(look, item, "show_dot_crosshair", "Lines through dot")
+            self._grid_appearance(look, item)
+            self._crosshair_appearance(look, item)
+        invert_types = {
+            "axis_bar",
+            "axis_radio",
+            "axis_fader",
+            "axis_radial",
+            "axis_encoder",
+            "axis_dial",
+        }
+        if types <= invert_types:
+            self._style_bool(look, item, "invert_display", "Invert")
+        if types <= {"axis_bar"}:
+            self._axis_appearance(look, item, self._bar_label_ends(item), invert=False)
+        elif types <= {"axis_stick_square", "axis_stick_circle", "axis_crosshair", "hat"}:
+            self._axis_appearance(look, item)
+        if not types.intersection({"label", "panel", "shape", "image", "streamdeck"}):
+            self._deadzone_field(look, item)
+        if types <= {"button"}:
+            self._border_appearance(look, item, colors=(("border", "Off border"), ("border_on", "On border")))
+        elif types <= {"axis_radio"}:
+            self._border_appearance(look, item, colors=(("border", "Off border"), ("border_on", "Active border")), include_radius=False)
+        else:
+            include_radius = not types <= set(NO_CORNER_RADIUS_TYPES)
+            self._border_appearance(look, item, include_radius=include_radius)
+
+    def _common_field(self, getter, fallback=None):
+        items = self.scene.selected_widgets()
+        if not items:
+            return fallback
+        values = [getter(w) for w in items]
+        if all(v == values[0] for v in values):
+            return values[0]
+        return fallback
+
+    def _set_bool_widget(self, box: QtWidgets.QCheckBox, values: list[bool]):
+        if len(values) > 1 and not all(v == values[0] for v in values):
+            box.setTristate(True)
+            box.setCheckState(QtCore.Qt.PartiallyChecked)
+        else:
+            box.setChecked(bool(values[0]) if values else False)
+
+    def _on_bool(self, box: QtWidgets.QCheckBox, widget_id: str, field: str | None = None, style_key: str | None = None):
+        if self._building:
+            return
+        if box.isTristate() and box.checkState() == QtCore.Qt.PartiallyChecked:
+            return
+        box.setTristate(False)
+        value = box.isChecked()
+        if field:
+            self._update(widget_id, **{field: value})
+        elif style_key:
+            self._style(widget_id, **{style_key: value})
+
+    def _bar_label_ends(self, item: dict) -> str | None:
+        items = self.scene.selected_widgets() if self._multi else [item]
+        vertical = []
+        for widget in items:
+            orient = ((widget.get("style") or {}).get("orientation") or "vertical").casefold()
+            vertical.append(orient != "horizontal")
+        if vertical and all(vertical):
+            return "ns"
+        if vertical and not any(vertical):
+            return "ew"
+        return "all"
+
+    def _axis_label_fields(self, form, item, ends: str | None = "all"):
+        self._style_bool(form, item, "show_axis_labels", "Axis labels")
+        pairs = (
+            ("axis_label_n", "North"),
+            ("axis_label_s", "South"),
+            ("axis_label_e", "East"),
+            ("axis_label_w", "West"),
+        )
+        if ends == "ns":
+            pairs = pairs[:2]
+        elif ends == "ew":
+            pairs = pairs[2:]
+        for key, title in pairs:
+            edit = QtWidgets.QLineEdit(item["style"].get(key) or "")
+            edit.editingFinished.connect(lambda wid=item["id"], k=key, w=edit: self._style(wid, **{k: w.text()}))
+            form.addRow(title, edit)
+        spread = item["style"].get("axis_label_spread")
+        self._slider_int(
+            form,
+            "Distance from center",
+            100 if spread is None else int(spread),
+            0,
+            100,
+            lambda v, wid=item["id"]: self._style(wid, axis_label_spread=int(v)),
+            tooltip="How far N/S/E/W labels sit from the center. 100 places them near the border with even padding.",
+        )
+        self._style_font(form, item, prefix="axis_label_")
+        self._style_color(form, item, "axis_label_font_color", "Axis label color")
+
+    def _orientation_combo(self, form, item, default="vertical"):
+        orient = QtWidgets.QComboBox()
+        orient.addItems(["vertical", "horizontal"])
+        orient.setCurrentText(item["style"].get("orientation") or default)
+        orient.currentTextChanged.connect(lambda v, wid=item["id"]: self._set_orientation(wid, v))
+        form.addRow("Orientation", orient)
+
+    def _set_orientation(self, widget_id: str, orientation: str):
+        if self._building:
+            return
+        ids = list(self._edit_ids or [widget_id])
+        self.scene._suspend += 1
+        try:
+            for wid in ids:
+                item = self.scene.widget_by_id(wid)
+                if not item:
+                    continue
+                previous = (item["style"].get("orientation") or "vertical")
+                fields = {"style": {"orientation": orientation}}
+                if previous != orientation:
+                    width, height = int(item["w"]), int(item["h"])
+                    vertical = orientation != "horizontal"
+                    if vertical and width > height:
+                        fields["w"], fields["h"] = height, width
+                    elif not vertical and height > width:
+                        fields["w"], fields["h"] = height, width
+                self.scene.apply_widget_update(wid, **fields)
+        finally:
+            self.scene._suspend = max(0, self.scene._suspend - 1)
+            self.scene._dirty = True
+            self.scene._emit()
+        self.rebuild()
+
+    def _indicator_shape(self, form, item):
+        shape = QtWidgets.QComboBox()
+        shape.addItems(["circle", "square"])
+        shape.setCurrentText(item["style"].get("indicator_shape") or "circle")
+        shape.currentTextChanged.connect(lambda v, wid=item["id"]: self._style(wid, indicator_shape=v))
+        form.addRow("Dot shape", shape)
+
+    def _angle_step_combo(self, form, item):
+        combo = QtWidgets.QComboBox()
+        for label, value in (("Off", 0), ("15°", 15), ("30°", 30), ("45°", 45)):
+            combo.addItem(label, value)
+        current = int(item["style"].get("angle_step") or 0)
+        index = {0: 0, 15: 1, 30: 2, 45: 3}.get(current, 0)
+        combo.setCurrentIndex(index)
+        combo.currentIndexChanged.connect(
+            lambda _i, wid=item["id"], box=combo: self._style(wid, angle_step=int(box.currentData()))
+        )
+        form.addRow("Angle lines", combo)
+
+    def _slider_int(self, form, title: str, value: int, lo: int, hi: int, on_change, tooltip=None):
+        value = int(value)
+        lo, hi = int(lo), int(hi)
+        if hi < lo:
+            lo, hi = hi, lo
+        if value < lo:
+            lo = value
+        if value > hi:
+            hi = value
+        row = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        slider.setRange(lo, hi)
+        slider.setValue(value)
+        spin = QtWidgets.QSpinBox()
+        spin.setRange(lo, hi)
+        spin.setValue(value)
+        spin.setMaximumWidth(80)
+        if tooltip:
+            row.setToolTip(tooltip)
+            slider.setToolTip(tooltip)
+            spin.setToolTip(tooltip)
+
+        def _from_slider(v, box=spin, cb=on_change):
+            box.blockSignals(True)
+            box.setValue(v)
+            box.blockSignals(False)
+            cb(v)
+
+        def _from_spin(v, bar=slider, cb=on_change):
+            bar.blockSignals(True)
+            bar.setValue(v)
+            bar.blockSignals(False)
+            cb(v)
+
+        slider.valueChanged.connect(_from_slider)
+        spin.valueChanged.connect(_from_spin)
+        layout.addWidget(slider, 1)
+        layout.addWidget(spin, 0)
+        form.addRow(title, row)
+
+    def _build_palettes(self, form, item: dict):
+        widget_type = palette_type(item.get("type"))
+        form.addRow("Default palettes", self._palette_swatch_row(widget_type, list_builtin_palettes(widget_type), editable=False))
+        form.addRow("User palettes", self._palette_swatch_row(widget_type, list_user_palettes(widget_type), editable=True, add_new=True))
+
+    def _palette_swatch_row(self, widget_type: str, palettes: list, editable: bool, add_new: bool = False) -> QtWidgets.QWidget:
+        host = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(host)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        for pal in palettes:
+            swatch = PaletteSwatch(pal.get("colors") or {}, pal.get("label") or "Saved palette", editable=editable)
+            swatch.apply_requested.connect(lambda p=pal: self._apply_palette(p))
+            if editable:
+                swatch.update_requested.connect(lambda pid=pal.get("id"): self._update_saved_palette(widget_type, pid))
+                swatch.delete_requested.connect(lambda pid=pal.get("id"): self._delete_saved_palette(widget_type, pid))
+            layout.addWidget(swatch)
+        if add_new:
+            add_btn = QtWidgets.QPushButton("+")
+            add_btn.setFixedSize(28, 28)
+            add_btn.setToolTip("Save the current colors as a new user palette for this widget type.")
+            add_btn.clicked.connect(lambda _=False: self._add_saved_palette(widget_type))
+            layout.addWidget(add_btn)
+        layout.addStretch()
+        return host
+
+    def _current_palette_colors(self) -> dict[str, str]:
+        items = self.scene.selected_widgets()
+        if not items:
+            return extract_colors({}, "button")
+        item = items[0]
+        return extract_colors(item.get("style") or {}, item.get("type"))
+
+    def _apply_palette(self, palette: dict):
+        colors = palette.get("colors") or {}
+        payload = {key: colors[key] for key in COLOR_KEYS if key in colors}
+        if not payload or not self._edit_ids:
+            return
+        self._style(self._edit_ids[0], **payload)
+        self.rebuild()
+
+    def _add_saved_palette(self, widget_type: str):
+        add_palette(widget_type, self._current_palette_colors())
+        self.rebuild()
+
+    def _update_saved_palette(self, widget_type: str, palette_id: str):
+        if not palette_id or palette_id in BUILTIN_IDS:
+            return
+        update_palette(widget_type, palette_id, self._current_palette_colors())
+        self.rebuild()
+
+    def _delete_saved_palette(self, widget_type: str, palette_id: str):
+        if not palette_id or palette_id in BUILTIN_IDS:
+            return
+        delete_palette(widget_type, palette_id)
+        self.rebuild()
+
+    def _look_heading(self, form: QtWidgets.QFormLayout, title: str):
+        label = QtWidgets.QLabel(title)
+        label.setStyleSheet("font-weight: bold; padding-top: 8px;")
+        form.addRow(label)
+
+    def _opacity_slider(self, form, item: dict):
+        raw = (item.get("style") or {}).get("opacity")
+        try:
+            value = 100 if raw is None else int(round(float(raw) * 100.0))
+        except (TypeError, ValueError):
+            value = 100
+        value = max(0, min(100, value))
+        self._slider_int(
+            form,
+            "Opacity",
+            value,
+            0,
+            100,
+            lambda v, wid=item["id"]: self._style(wid, opacity=max(0.0, min(1.0, float(v) / 100.0))),
+            tooltip="Widget opacity (percent).",
+        )
+
+    def _deadzone_field(self, form, item: dict):
+        dead = QtWidgets.QDoubleSpinBox()
+        dead.setRange(0.0, 0.9)
+        dead.setSingleStep(0.01)
+        dead.setValue(float(item["style"].get("deadzone") or 0))
+        dead.setToolTip("Overlay only: axis values inside this range around center are drawn as zero. Does not change GEX mappings.")
+        dead.valueChanged.connect(lambda v, wid=item["id"]: self._style(wid, deadzone=float(v)))
+        form.addRow("Deadzone display", dead)
+
+    def _axis_appearance(self, form, item: dict, ends: str | None = "all", invert: bool = False):
+        self._look_heading(form, "Axis")
+        if invert:
+            self._style_bool(form, item, "invert_display", "Invert display")
+        self._axis_label_fields(form, item, ends)
+
+    def _border_appearance(self, form, item: dict, colors=None, include_radius: bool = True):
+        self._look_heading(form, "Border")
+        if colors:
+            for key, title in colors:
+                self._style_color(form, item, key, title)
+        else:
+            self._style_color(form, item, "border", "Border")
+        self._style_float(form, item, "border_width", "Border width", 0, 20)
+        if include_radius:
+            self._style_float(form, item, "corner_radius", "Corner radius", 0, 200)
+
+    def _append_shared_appearance(self, look, item: dict, widget_type: str):
+        axis_label_types = {"axis_bar", "axis_stick_square", "axis_stick_circle", "axis_crosshair", "hat"}
+        if widget_type in axis_label_types:
+            ends = self._bar_label_ends(item) if widget_type == "axis_bar" else "all"
+            self._axis_appearance(look, item, ends, invert=widget_type == "axis_bar")
+        if widget_type not in ("label", "panel", "shape", "image", "streamdeck"):
+            self._deadzone_field(look, item)
+        if widget_type == "button":
+            self._border_appearance(look, item, colors=(("border", "Off border"), ("border_on", "On border")))
+        elif widget_type == "axis_radio":
+            self._border_appearance(
+                look,
+                item,
+                colors=(("border", "Off border"), ("border_on", "Active border")),
+                include_radius=False,
+            )
+        elif widget_type not in ("label", "shape", "panel", "image", "streamdeck"):
+            self._border_appearance(look, item, include_radius=widget_type not in NO_CORNER_RADIUS_TYPES)
+        if widget_type not in ("label", "panel", "shape", "image", "streamdeck") and not self._multi:
+            self._build_binding(item)
+
+    def _grid_appearance(self, form, item: dict):
+        self._look_heading(form, "Grid")
+        self._style_bool(form, item, "show_grid", "Show grid")
+        self._style_color(form, item, "grid", "Grid")
+        self._style_float(form, item, "grid_width", "Line width", 0.5, 12)
+        self._style_bool(
+            form,
+            item,
+            "grid_fade",
+            "Fade at border",
+            tooltip="Keep the grid full strength in the center and fade it toward the widget border.",
+        )
+
+    def _crosshair_appearance(self, form, item: dict, show_toggle: bool = True):
+        self._look_heading(form, "Crosshairs")
+        if show_toggle:
+            self._style_bool(form, item, "show_center_line", "Show crosshairs")
+        self._style_color(form, item, "crosshair", "Crosshair")
+
+    def _shape_appearance(self, form, item: dict):
+        kind = QtWidgets.QComboBox()
+        current = normalize_shape_kind(item["style"].get("shape_kind"))
+        for stored, label in SHAPE_KIND_LABELS:
+            kind.addItem(label, stored)
+        index = kind.findData(current)
+        if index >= 0:
+            kind.setCurrentIndex(index)
+        kind.currentIndexChanged.connect(lambda _i, box=kind, wid=item["id"]: self._set_shape_kind(wid, box.currentData()))
+        form.addRow("Shape", kind)
+        self._style_bool(
+            form,
+            item,
+            "shape_closed",
+            "Closed",
+            tooltip="Connect the last point back to the first. Off for an open line or path.",
+        )
+        hint = QtWidgets.QLabel("Freeform: double-click the outline to add a point. Drag points, then drag the yellow handles to curve a corner. Delete removes the selected point.")
+        hint.setWordWrap(True)
+        form.addRow(hint)
+        self._style_color(form, item, "fill", "Fill")
+        self._look_heading(form, "Border")
+        self._style_color(form, item, "border", "Border")
+        self._style_float(form, item, "border_width", "Border width", 0, 20)
+        if current == "rectangle":
+            self._style_float(form, item, "corner_radius", "Corner radius", 0, 200)
+
+    def _image_appearance(self, form, item: dict):
+        path_row = QtWidgets.QWidget()
+        path_layout = QtWidgets.QHBoxLayout(path_row)
+        path_layout.setContentsMargins(0, 0, 0, 0)
+        path_edit = QtWidgets.QLineEdit(item["style"].get("image_path") or "")
+        browse = QtWidgets.QPushButton("...")
+        browse.setFixedWidth(28)
+        browse.clicked.connect(lambda _=False, wid=item["id"]: self._browse_image(wid))
+        path_edit.editingFinished.connect(lambda wid=item["id"], w=path_edit: self._style(wid, image_path=w.text()))
+        path_layout.addWidget(path_edit)
+        path_layout.addWidget(browse)
+        form.addRow("Image", path_row)
+        self._style_bool(
+            form,
+            item,
+            "image_keep_aspect",
+            "Keep aspect ratio",
+            tooltip="Fit the picture inside the widget. Off stretches it to the widget size.",
+        )
+        hint = QtWidgets.QLabel("PNG, WebP, and GIF keep their transparency. Fill is only a backdrop behind those pixels. JPEG has no alpha.")
+        hint.setWordWrap(True)
+        form.addRow(hint)
+        self._style_color(form, item, "fill", "Fill")
+        self._look_heading(form, "Border")
+        self._style_color(form, item, "border", "Border")
+        self._style_float(form, item, "border_width", "Border width", 0, 20)
+
+    def _streamdeck_appearance(self, form, item: dict):
+        try:
+            from gremlin.ui.streamdeck_device import (
+                StreamDeckBridge,
+                friendly_streamdeck_name,
+            )
+
+            bridge = StreamDeckBridge()
+        except Exception:
+            form.addRow(QtWidgets.QLabel("Stream Deck bridge is unavailable."))
+            return
+
+        style = item.get("style") or {}
+        wanted = str(style.get("streamdeck_device_id") or "")
+        combo = QtWidgets.QComboBox()
+        combo.addItem("First connected", "")
+        seen = set()
+        for device_id, info in (bridge.devices or {}).items():
+            info = info or {}
+            label = friendly_streamdeck_name(info.get("name"), info.get("type"), device_id)
+            combo.addItem(label, device_id)
+            seen.add(device_id)
+        if wanted and wanted not in seen:
+            combo.addItem(f"Disconnected ({wanted[:8]})", wanted)
+        idx = combo.findData(wanted)
+        combo.setCurrentIndex(idx if idx >= 0 else 0)
+        combo.currentIndexChanged.connect(
+            lambda _i, w=combo, wid=item["id"]: self._on_streamdeck_device(wid, w.currentData() or "")
+        )
+        form.addRow("Device", combo)
+
+        follow = bool(style.get("streamdeck_follow_page", True))
+        page_combo = QtWidgets.QComboBox()
+        device_id = bridge.resolve_overlay_device_id(wanted)
+        pages = bridge.list_pages(device_id) if device_id else [1]
+        current_page = int(style.get("streamdeck_page") or 1)
+        for page in pages:
+            name = bridge.page_name(device_id, page) if device_id else f"Page {page}"
+            if name and name != f"Page {page}" and not str(name).startswith(f"{page}."):
+                label = f"{page}. {name}"
+            else:
+                label = name or f"Page {page}"
+            page_combo.addItem(label, page)
+        pidx = page_combo.findData(current_page)
+        if pidx < 0:
+            page_combo.addItem(f"Page {current_page}", current_page)
+            pidx = page_combo.findData(current_page)
+        page_combo.setCurrentIndex(pidx if pidx >= 0 else 0)
+        page_combo.setEnabled(not follow)
+        page_combo.currentIndexChanged.connect(
+            lambda _i, w=page_combo, wid=item["id"]: self._style(wid, streamdeck_page=int(w.currentData() or 1))
+        )
+
+        follow_box = QtWidgets.QCheckBox()
+        follow_box.setChecked(follow)
+        follow_box.setToolTip("Show the GEX virtual page currently painted on the hardware.")
+        follow_box.stateChanged.connect(
+            lambda _s, wid=item["id"], box=follow_box, combo=page_combo: self._on_streamdeck_follow(wid, box, combo)
+        )
+        form.addRow("Follow hardware page", follow_box)
+        form.addRow("Page", page_combo)
+        self._style_bool(
+            form,
+            item,
+            "show_bezel",
+            "Show bezel",
+            tooltip="Draw the Stream Deck body around the keys.",
+        )
+        fit = QtWidgets.QPushButton("Fit to device")
+        fit.setToolTip("Resize this widget to the key layout of the selected Stream Deck.")
+        fit.clicked.connect(lambda _=False, wid=item["id"]: self._fit_streamdeck_item(wid, force=True))
+        form.addRow(fit)
+        hint = QtWidgets.QLabel("Mirrors the selected deck’s keys (and Stream Deck + dials) using the current GEX page art.")
+        hint.setWordWrap(True)
+        form.addRow(hint)
+        self._style_color(form, item, "fill", "Bezel")
+        self._look_heading(form, "Border")
+        self._style_color(form, item, "border", "Border")
+        self._style_float(form, item, "border_width", "Border width", 0, 20)
+        self._style_float(form, item, "corner_radius", "Corner radius", 0, 200)
+
+    def _on_streamdeck_follow(self, widget_id: str, box: QtWidgets.QCheckBox, page_combo: QtWidgets.QComboBox):
+        if self._building:
+            return
+        follow = box.isChecked()
+        self._style(widget_id, streamdeck_follow_page=bool(follow))
+        page_combo.setEnabled(not follow)
+
+    def _on_streamdeck_device(self, widget_id: str, device_id: str):
+        if self._building:
+            return
+        item = self.scene.widget_by_id(widget_id)
+        if not item:
+            return
+        self.scene.push_undo()
+        item["style"]["streamdeck_device_id"] = device_id or ""
+        self._fit_streamdeck_geometry(item)
+        self.scene._dirty = True
+        self.scene._emit()
+        self.rebuild()
+
+    def _fit_streamdeck_item(self, widget_id: str, force: bool = False):
+        if self._building:
+            return
+        item = self.scene.widget_by_id(widget_id)
+        if not item:
+            return
+        self.scene.push_undo()
+        self._fit_streamdeck_geometry(item, force=force)
+        self.scene._dirty = True
+        self.scene._emit()
+        self.rebuild()
+
+    def _fit_streamdeck_geometry(self, item: dict, force: bool = True):
+        from .model import DEFAULT_SIZES
+        from .widgets import streamdeck_preferred_size
+
+        try:
+            from gremlin.ui.streamdeck_device import StreamDeckBridge
+
+            bridge = StreamDeckBridge()
+            device_id = bridge.resolve_overlay_device_id(str((item.get("style") or {}).get("streamdeck_device_id") or ""))
+            info = bridge.devices.get(device_id, {}) if device_id else {}
+            width, height = streamdeck_preferred_size((info or {}).get("type"))
+        except Exception:
+            width, height = DEFAULT_SIZES.get("streamdeck", (320, 208))
+        current = (int(item.get("w") or 0), int(item.get("h") or 0))
+        default = tuple(int(v) for v in DEFAULT_SIZES.get("streamdeck", (320, 208)))
+        if not force and current not in (default, (0, 0)):
+            return
+        canvas_w = max(32, int(self.scene.canvas.get("width") or 1280))
+        canvas_h = max(32, int(self.scene.canvas.get("height") or 720))
+        scale = min(1.0, canvas_w / max(1, width), canvas_h / max(1, height))
+        width = max(48, int(round(width * scale)))
+        height = max(48, int(round(height * scale)))
+        cx = int(item.get("x") or 0) + int(item.get("w") or 0) / 2.0
+        cy = int(item.get("y") or 0) + int(item.get("h") or 0) / 2.0
+        item["w"] = width
+        item["h"] = height
+        item["x"] = max(0, min(canvas_w - width, int(round(cx - width / 2.0))))
+        item["y"] = max(0, min(canvas_h - height, int(round(cy - height / 2.0))))
+
+    def _browse_image(self, widget_id: str):
+        if self._building:
+            return
+        item = self.scene.widget_by_id(widget_id)
+        if not item:
+            return
+        start = (item.get("style") or {}).get("image_path") or ""
+        fname, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Overlay image",
+            start,
+            "Images (*.png *.jpg *.jpeg *.bmp *.webp *.gif)",
+        )
+        if not fname:
+            return
+        self.scene.push_undo()
+        item["style"]["image_path"] = fname
+        self._fit_item_to_image(item, fname)
+        self.scene._dirty = True
+        self.scene._emit()
+        self.rebuild()
+
+    def _fit_item_to_image(self, item: dict, path: str):
+        image = QtGui.QImage(path)
+        if image.isNull():
+            return
+        canvas_w = max(32, int(self.scene.canvas.get("width") or 1280))
+        canvas_h = max(32, int(self.scene.canvas.get("height") or 720))
+        scale = min(1.0, canvas_w / max(1, image.width()), canvas_h / max(1, image.height()))
+        width = max(16, int(round(image.width() * scale)))
+        height = max(16, int(round(image.height() * scale)))
+        cx = int(item.get("x") or 0) + int(item.get("w") or 0) / 2.0
+        cy = int(item.get("y") or 0) + int(item.get("h") or 0) / 2.0
+        item["w"] = width
+        item["h"] = height
+        item["x"] = max(0, min(canvas_w - width, int(round(cx - width / 2.0))))
+        item["y"] = max(0, min(canvas_h - height, int(round(cy - height / 2.0))))
+
+    def _set_shape_kind(self, widget_id: str, kind):
+        if self._building:
+            return
+        kind = normalize_shape_kind(kind)
+        item = self.scene.widget_by_id(widget_id)
+        if not item:
+            return
+        self.scene.push_undo()
+        item["style"]["shape_kind"] = kind
+        item["style"]["shape_closed"] = kind != "line"
+        item["points"] = default_shape_points(kind)
+        self.scene._dirty = True
+        self.scene._emit()
+        self.rebuild()
+
+    def _style_color(self, form, item, key, title):
+        values = [(w.get("style") or {}).get(key) for w in self.scene.selected_widgets()] or [item["style"].get(key)]
+        same = all(v == values[0] for v in values)
+        btn = ColorButton(values[0] or "#ffffff")
+        if not same:
+            btn.setToolTip("Multiple values — pick a color to apply to all")
+        btn.color_changed.connect(lambda v, wid=item["id"], k=key: self._style(wid, **{k: v}))
+        form.addRow(title, btn)
+
+    def _style_float(self, form, item, key, title, lo, hi, step=0.5):
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setRange(lo, hi)
+        spin.setSingleStep(step)
+        spin.setValue(float(item["style"].get(key) or lo))
+        spin.valueChanged.connect(lambda v, wid=item["id"], k=key: self._style(wid, **{k: float(v)}))
+        form.addRow(title, spin)
+
+    def _style_bool(self, form, item, key, title, tooltip=None):
+        fallback = bool(default_style(item.get("type") or "button").get(key, False))
+        values = [bool((w.get("style") or {}).get(key, fallback)) for w in self.scene.selected_widgets()]
+        if not values:
+            values = [bool(item["style"].get(key, fallback))]
+        box = QtWidgets.QCheckBox()
+        self._set_bool_widget(box, values)
+        if tooltip:
+            box.setToolTip(tooltip)
+        box.stateChanged.connect(lambda _s, wid=item["id"], k=key, b=box: self._on_bool(b, wid, style_key=k))
+        form.addRow(title, box)
+
+    def _style_font(self, form, item, prefix=""):
+        family_key = f"{prefix}font_family"
+        size_key = f"{prefix}font_size"
+        bold_key = f"{prefix}font_bold"
+        combo = QtWidgets.QFontComboBox()
+        family = item["style"].get(family_key) or item["style"].get("font_family") or "Segoe UI"
+        combo.setCurrentFont(QtGui.QFont(family))
+        idx = combo.findText(family)
+        if idx >= 0:
+            combo.setCurrentIndex(idx)
+        combo.currentTextChanged.connect(lambda v, wid=item["id"], k=family_key: self._style(wid, **{k: v}))
+        size = QtWidgets.QSpinBox()
+        size.setRange(6, 192)
+        size.setValue(effective_font_size(item, size_key))
+        size.setToolTip("Drawn font size. Updates while the widget is resized when Scale font with size is on.")
+        size.valueChanged.connect(lambda v, wid=item["id"], k=size_key: self._style(wid, **{k: int(v)}))
+        self._bind_live(size, lambda it=item, k=size_key: effective_font_size(it, k))
+        bold = QtWidgets.QCheckBox()
+        bold.setChecked(bool(item["style"].get(bold_key, item["style"].get("font_bold", True))))
+        bold.toggled.connect(lambda v, wid=item["id"], k=bold_key: self._style(wid, **{k: v}))
+        label = "Axis font" if prefix else "Font"
+        form.addRow(label, combo)
+        form.addRow(f"{label} size", size)
+        form.addRow(f"{label} bold", bold)
+
+    def _build_toggle_binding(self):
+        binding = normalize_toggle_binding(self.scene.canvas.get("toggle_binding"))
+        # Canvas show/hide is a button (or state) assignment — not a free-form
+        # axis/hat binding editor. Force button so Input type / Invert stay hidden.
+        binding["input_type"] = "button"
+        self.scene.canvas["toggle_binding"] = binding
+        item = {"id": CANVAS_TOGGLE_ID, "type": "button", "binding": binding}
+        self._build_channel(
+            item,
+            "binding",
+            "Toggle overlay",
+            force_type="button",
+            allow_none=True,
+            show_clear=True,
+            show_invert=False,
+            extra_hint="While the profile is running, press this button to show or hide this page’s overlay window.",
+        )
+
+    def _build_binding(self, item: dict):
+        if widget_needs_xy(item.get("type")):
+            self._build_channel(item, "binding", "Axis X", force_type="axis")
+            self._build_channel(item, "binding_y", "Axis Y", force_type="axis")
+            return
+        widget_type = item.get("type")
+        force = None
+        if widget_type == "button":
+            force = "button"
+        elif widget_type == "hat":
+            force = "hat"
+        elif widget_type and str(widget_type).startswith("axis"):
+            force = "axis"
+        self._build_channel(item, "binding", "Binding", force_type=force)
+
+    def _channel_binding(self, item: dict, channel: str) -> dict:
+        binding = item.get(channel)
+        if not isinstance(binding, dict):
+            binding = {}
+            item[channel] = binding
+        return binding
+
+    def _build_channel(
+        self,
+        item: dict,
+        channel: str,
+        title: str,
+        force_type: str | None = None,
+        allow_none: bool = False,
+        extra_hint: str | None = None,
+        show_clear: bool = False,
+        show_invert: bool = True,
+    ):
+        form = self._section(title)
+        binding = self._channel_binding(item, channel)
+        sources = ["physical", "vjoy"]
+        if force_type != "axis" or not widget_needs_xy(item.get("type")):
+            sources.append("state")
+        source = QtWidgets.QComboBox()
+        source.addItems(sources)
+        current_source = binding.get("source") or "physical"
+        if current_source not in sources:
+            current_source = "physical"
+        source.setCurrentText(current_source)
+        source.currentTextChanged.connect(lambda v, wid=item["id"], ch=channel: self._bind(wid, ch, rebuild=True, source=v))
+        form.addRow("Source", source)
+
+        if source.currentText() == "state":
+            names = [""]
+            try:
+                from gremlin.ui import state_device
+
+                names.extend(state_device.StateData().getStateNames())
+            except Exception:
+                pass
+            combo = QtWidgets.QComboBox()
+            combo.setEditable(True)
+            combo.addItems(names)
+            combo.setCurrentText(binding.get("state_name") or "")
+            combo.currentTextChanged.connect(lambda v, wid=item["id"], ch=channel: self._bind(wid, ch, state_name=v, input_type="state"))
+            form.addRow("State", combo)
+            self._finish_channel(form, item, channel, extra_hint, show_clear)
+            return
+
+        device_box = QtWidgets.QComboBox()
+        if source.currentText() == "vjoy":
+            for dev in gremlin.joystick_handling.vjoy_devices(connected_only=False) or []:
+                device_box.addItem(f"vJoy {dev.vjoy_id} ({dev.name})", dev)
+            current = int(binding.get("vjoy_id") or 0)
+            for i in range(device_box.count()):
+                if getattr(device_box.itemData(i), "vjoy_id", None) == current:
+                    device_box.setCurrentIndex(i)
+                    break
+            shown = device_box.currentData()
+            if shown is not None and current <= 0:
+                binding["vjoy_id"] = int(shown.vjoy_id)
+                binding["device_guid"] = str(shown.device_guid)
+                binding["device_name"] = shown.name
+                item.setdefault(channel, {}).update(
+                    {
+                        "vjoy_id": binding["vjoy_id"],
+                        "device_guid": binding["device_guid"],
+                        "device_name": binding["device_name"],
+                    }
+                )
+                self.scene._dirty = True
+        else:
+            devices = gremlin.joystick_handling.physical_devices() or gremlin.joystick_handling.joystick_devices()
+            for dev in devices or []:
+                if getattr(dev, "is_virtual", False):
+                    continue
+                device_box.addItem(dev.name, dev)
+            current = str(binding.get("device_guid") or "")
+            for i in range(device_box.count()):
+                dev = device_box.itemData(i)
+                if dev and str(dev.device_guid).casefold() == current.casefold():
+                    device_box.setCurrentIndex(i)
+                    break
+
+        def _device_changed():
+            dev = device_box.currentData()
+            if not dev:
+                return
+            payload = {"device_name": dev.name, "device_guid": str(dev.device_guid)}
+            if source.currentText() == "vjoy":
+                payload["vjoy_id"] = int(dev.vjoy_id)
+            self._bind(item["id"], channel, rebuild=True, **payload)
+
+        device_box.currentIndexChanged.connect(_device_changed)
+        form.addRow("Device", device_box)
+
+        listen = QtWidgets.QPushButton("Listen...")
+        listen.setToolTip("Assign from the next matching physical or vJoy input")
+        listen.clicked.connect(lambda _=False, it=item, ch=channel, kind=force_type: self._listen(it, ch, kind))
+        form.addRow("", listen)
+
+        input_kind = force_type or binding.get("input_type") or "axis"
+        if not force_type:
+            input_type = QtWidgets.QComboBox()
+            types = ["axis", "button", "hat"]
+            input_type.addItems(types)
+            if input_kind not in types:
+                input_kind = "axis"
+            input_type.setCurrentText(input_kind)
+            input_type.currentTextChanged.connect(lambda v, wid=item["id"], ch=channel: self._bind(wid, ch, rebuild=True, input_type=v))
+            form.addRow("Input type", input_type)
+        else:
+            if binding.get("input_type") != force_type:
+                binding["input_type"] = force_type
+            input_kind = force_type
+
+        device = device_box.currentData()
+        id_box = QtWidgets.QComboBox()
+        if allow_none:
+            id_box.addItem("(none)", 0)
+        choices = self._input_choices(device, input_kind)
+        try:
+            current_id = int(binding.get("input_id") or 0)
+        except (TypeError, ValueError):
+            current_id = 0
+        if not allow_none and current_id <= 0:
+            current_id = int(choices[0][0]) if choices else 1
+        found = False
+        for axis_id, label in choices:
+            id_box.addItem(label, axis_id)
+            if int(axis_id) == current_id:
+                id_box.setCurrentIndex(id_box.count() - 1)
+                found = True
+        if not found:
+            if allow_none and current_id <= 0:
+                id_box.setCurrentIndex(0)
+                found = True
+            else:
+                id_box.addItem(f"{input_kind.capitalize()} {current_id}", current_id)
+                id_box.setCurrentIndex(id_box.count() - 1)
+        id_box.currentIndexChanged.connect(
+            lambda _i, wid=item["id"], ch=channel, box=id_box, kind=input_kind: self._bind(
+                wid, ch, input_type=kind, input_id=int(box.currentData() if box.currentData() is not None else 0)
+            )
+        )
+        form.addRow("Axis" if input_kind == "axis" else input_kind.capitalize(), id_box)
+
+        if show_invert:
+            inv = QtWidgets.QCheckBox()
+            inv.setChecked(bool(binding.get("invert")))
+            inv.toggled.connect(lambda v, wid=item["id"], ch=channel: self._bind(wid, ch, invert=v))
+            form.addRow("Invert", inv)
+
+        hint = QtWidgets.QLabel(self._channel_summary(binding, input_kind))
+        hint.setWordWrap(True)
+        form.addRow("Assigned", hint)
+        self._finish_channel(form, item, channel, extra_hint, show_clear)
+
+    def _finish_channel(self, form, item: dict, channel: str, extra_hint: str | None, show_clear: bool):
+        if extra_hint:
+            note = QtWidgets.QLabel(extra_hint)
+            note.setWordWrap(True)
+            form.addRow(note)
+        if show_clear:
+            clear = QtWidgets.QPushButton("Clear")
+            clear.clicked.connect(
+                lambda _=False, wid=item["id"], ch=channel: self._bind(
+                    wid,
+                    ch,
+                    rebuild=True,
+                    device_guid="",
+                    device_name="",
+                    vjoy_id=0,
+                    input_id=0,
+                    state_name="",
+                )
+            )
+            form.addRow("", clear)
+
+    def _input_choices(self, device, input_kind: str) -> list[tuple[int, str]]:
+        if input_kind == "axis":
+            choices = []
+            maps = getattr(device, "axismap_list", None) or [] if device else []
+            for am in maps:
+                axis_id = getattr(am, "axis_index", 0)
+                if not axis_id:
+                    continue
+                try:
+                    axis_name = gremlin.joystick_handling.get_axis_name(axis_id)
+                except Exception:
+                    axis_name = str(axis_id)
+                try:
+                    device_name = device.get_axis_name(axis_id) if device else None
+                except Exception:
+                    device_name = None
+                label = f"Axis {axis_id} ({axis_name})"
+                if device_name and str(device_name) not in label:
+                    label = f"{label} — {device_name}"
+                choices.append((int(axis_id), label))
+            if choices:
+                return choices
+            count = int(getattr(device, "axis_count", 0) or 0) if device else 8
+            for i in range(1, max(1, count) + 1):
+                try:
+                    axis_name = gremlin.joystick_handling.get_axis_name(i)
+                except Exception:
+                    axis_name = str(i)
+                choices.append((i, f"Axis {i} ({axis_name})"))
+            return choices or [(1, "Axis 1 (X)"), (2, "Axis 2 (Y)")]
+        if input_kind == "button":
+            count = int(getattr(device, "button_count", 0) or 0) if device else 16
+            return [(i, f"Button {i}") for i in range(1, max(1, count) + 1)]
+        count = int(getattr(device, "hat_count", 0) or 0) if device else 4
+        return [(i, f"Hat {i}") for i in range(1, max(1, count) + 1)]
+
+    def _channel_summary(self, binding: dict, input_kind: str) -> str:
+        source = binding.get("source") or "physical"
+        if source == "state":
+            return binding.get("state_name") or "(none)"
+        try:
+            input_id = int(binding.get("input_id") or 0)
+        except (TypeError, ValueError):
+            input_id = 0
+        if input_id <= 0:
+            return "(none)"
+        name = binding.get("device_name") or "—"
+        return f"{name}  {input_kind.capitalize()} {input_id}"
+
+    def _listen(self, item: dict, channel: str = "binding", force_type: str | None = None):
+        types = [InputType.JoystickAxis, InputType.JoystickButton, InputType.JoystickHat]
+        widget_type = item.get("type")
+        if force_type == "axis" or (widget_type and str(widget_type).startswith("axis")):
+            types = [InputType.JoystickAxis]
+        elif force_type == "button" or widget_type == "button":
+            types = [InputType.JoystickButton]
+        elif force_type == "hat" or widget_type == "hat":
+            types = [InputType.JoystickHat]
+
+        def _captured(event):
+            input_type = "axis"
+            if event.event_type == InputType.JoystickButton:
+                input_type = "button"
+            elif event.event_type == InputType.JoystickHat:
+                input_type = "hat"
+            device = gremlin.joystick_handling.getDevice(event.device_guid, show_error=False)
+            payload = {
+                "source": "vjoy" if getattr(device, "is_virtual", False) else "physical",
+                "device_guid": str(event.device_guid),
+                "device_name": device.name if device else str(event.device_guid),
+                "vjoy_id": int(getattr(device, "vjoy_id", 0) or 0),
+                "input_type": input_type,
+                "input_id": int(event.identifier),
+            }
+            self._bind(item["id"], channel, rebuild=True, **payload)
+
+        listener = gremlin.ui.ui_common.InputListenerWidget(types, callback=_captured)
+        listener.show()
+
+    def _update(self, widget_id: str, **fields):
+        if self._building:
+            return
+        ids = list(self._edit_ids or [widget_id])
+        self.scene.apply_widget_updates(ids, **fields)
+
+    def _style(self, widget_id: str, **fields):
+        if self._building:
+            return
+        ids = list(self._edit_ids or [widget_id])
+        self.scene.apply_widget_updates(ids, style=fields)
+
+    def _bind(self, widget_id: str, channel: str = "binding", rebuild: bool = False, **fields):
+        if self._building:
+            return
+        if (fields.get("source") or "").casefold() == "vjoy" and not int(fields.get("vjoy_id") or 0):
+            devices = gremlin.joystick_handling.vjoy_devices(connected_only=False) or []
+            if devices:
+                fields["vjoy_id"] = int(devices[0].vjoy_id)
+                fields.setdefault("device_guid", str(devices[0].device_guid))
+                fields.setdefault("device_name", devices[0].name)
+        if widget_id == CANVAS_TOGGLE_ID:
+            binding = normalize_toggle_binding(self.scene.canvas.get("toggle_binding"))
+            binding.update(fields)
+            self.scene.canvas["toggle_binding"] = normalize_toggle_binding(binding)
+            self.scene._dirty = True
+            self.scene.changed.emit()
+            if rebuild:
+                self.rebuild()
+            return
+        self.scene.apply_widget_update(widget_id, **{channel: fields})
+        if rebuild:
+            self.rebuild()

--- a/gremlin/ui/obs_overlay/model.py
+++ b/gremlin/ui/obs_overlay/model.py
@@ -1,0 +1,1558 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+from PySide6 import QtCore
+from psygnal import Signal
+
+import gremlin.shared_state
+import gremlin.util
+
+syslog = logging.getLogger("system")
+
+SCENE_VERSION = 2
+OVERLAY_WINDOW_TITLE = "GEX Overlay"
+
+
+def overlay_window_title(page: dict[str, Any] | None = None, name: str | None = None) -> str:
+    label = str(name if name is not None else (page or {}).get("name") or "Overlay").strip() or "Overlay"
+    return f"{OVERLAY_WINDOW_TITLE} — {label}"
+
+
+def _optional_int(value) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+WIDGET_TYPES = (
+    "axis_bar",
+    "axis_radio",
+    "axis_fader",
+    "axis_radial",
+    "axis_encoder",
+    "axis_stick_square",
+    "axis_crosshair",
+    "axis_stick_circle",
+    "button",
+    "hat",
+    "label",
+    "shape",
+    "image",
+    "streamdeck",
+    "panel",  # legacy alias of shape
+    "axis_dial",  # legacy alias of axis_radial
+)
+
+PALETTE_TYPES = (
+    "axis_bar",
+    "axis_radio",
+    "axis_fader",
+    "axis_radial",
+    "axis_encoder",
+    "axis_stick_square",
+    "axis_crosshair",
+    "axis_stick_circle",
+    "button",
+    "hat",
+    "label",
+    "shape",
+    "image",
+    "streamdeck",
+)
+
+PALETTE_GROUPS = (
+    ("Single axis", ("axis_bar", "axis_radio", "axis_fader", "axis_radial", "axis_encoder")),
+    ("Double axis", ("axis_stick_square", "axis_crosshair", "axis_stick_circle")),
+    ("Other", ("button", "hat", "label", "shape", "image", "streamdeck")),
+)
+
+DEFAULT_SIZES = {
+    "axis_bar": (48, 180),
+    "axis_radio": (220, 36),
+    "axis_fader": (40, 180),
+    "axis_radial": (150, 150),
+    "axis_encoder": (150, 150),
+    "axis_dial": (150, 150),
+    "axis_stick_square": (168, 168),
+    "axis_stick_circle": (180, 180),
+    "axis_crosshair": (220, 220),
+    "button": (88, 32),
+    "hat": (108, 108),
+    "label": (140, 28),
+    "shape": (280, 160),
+    "image": (200, 120),
+    "streamdeck": (320, 208),
+    "panel": (280, 160),
+}
+
+DEFAULT_LABELS = {
+    "axis_bar": "",
+    "axis_radio": "",
+    "axis_fader": "",
+    "axis_radial": "",
+    "axis_encoder": "",
+    "axis_dial": "",
+    "axis_stick_square": "",
+    "axis_stick_circle": "",
+    "axis_crosshair": "",
+    "button": "BTN",
+    "hat": "",
+    "label": "Label",
+    "shape": "",
+    "image": "",
+    "streamdeck": "",
+    "panel": "",
+}
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def default_style(widget_type: str) -> dict[str, Any]:
+    """Default visual style for a widget type."""
+    style: dict[str, Any] = {
+        "fill": "#121826",
+        "fill_on": "#ff6b35",
+        "border": "#2c3a52",
+        "border_on": "#ffb347",
+        "border_width": 2.0,
+        "corner_radius": 6.0,
+        "indicator": "#ff5a3c",
+        "indicator_size": 12.0,
+        "track": "#0b1220",
+        "fill_bar": "#ff6b35",
+        "grid": "#2a3a55",
+        "grid_width": 1.0,
+        "crosshair": "#5a6a84",
+        "needle": "#ff5a3c",
+        "needle_width": 3.0,
+        "font_family": "Segoe UI",
+        "font_size": 11,
+        "font_bold": True,
+        "font_color": "#f4efe4",
+        "axis_label_font_family": "Segoe UI",
+        "axis_label_font_size": 11,
+        "axis_label_font_bold": True,
+        "axis_label_font_color": "#f4efe4",
+        "label_offset_x": 0,
+        "label_offset_y": 0,
+        "show_label": True,
+        "show_axis_labels": True,
+        "axis_label_n": "U",
+        "axis_label_s": "D",
+        "axis_label_e": "R",
+        "axis_label_w": "L",
+        "axis_label_spread": 100,
+        "orientation": "vertical",
+        "shape": "rounded",
+        "ring_count": 3,
+        "show_center_line": True,
+        "show_dot_crosshair": False,
+        "show_dot_shadow": True,
+        "show_grid": True,
+        "grid_fade": False,
+        "indicator_shape": "circle",
+        "angle_step": 0,
+        "radio_steps": 5,
+        "deadzone": 0.0,
+        "invert_display": False,
+        "opacity": 1.0,
+        "auto_scale_font": False,
+    }
+    if widget_type == "axis_bar":
+        style.update({"corner_radius": 6.0, "indicator_size": 14.0, "show_label": False, "show_dot_shadow": True})
+    elif widget_type == "axis_radio":
+        style.update({"orientation": "horizontal", "radio_steps": 5, "show_label": False})
+    elif widget_type == "axis_fader":
+        style.update(
+            {
+                "corner_radius": 4.0,
+                "indicator_size": 0.0,
+                "radio_steps": 8,
+                "show_label": False,
+                "fill_bar": "#b04a25",
+            }
+        )
+    elif widget_type in ("axis_radial", "axis_dial"):
+        style.update({"indicator_size": 10.0, "show_label": False, "needle_width": 14.0, "radio_steps": 11})
+    elif widget_type == "axis_encoder":
+        style.update({"show_label": False, "needle_width": 0.0, "radio_steps": 16})
+    elif widget_type == "axis_stick_square":
+        style.update(
+            {
+                "axis_label_n": "F",
+                "axis_label_s": "A",
+                "axis_label_e": "R",
+                "axis_label_w": "L",
+                "indicator_size": 14.0,
+                "show_label": False,
+            }
+        )
+    elif widget_type == "axis_stick_circle":
+        style.update({"indicator_size": 14.0, "show_label": False, "ring_count": 2})
+    elif widget_type == "axis_crosshair":
+        style.update(
+            {
+                "fill": "#0a1220",
+                "indicator_size": 14.0,
+                "show_label": False,
+                "ring_count": 3,
+            }
+        )
+    elif widget_type == "button":
+        style.update(
+            {
+                "fill": "#3a1518",
+                "fill_on": "#ff6b35",
+                "border": "#6a2a22",
+                "border_on": "#ffcc66",
+                "font_size": 10,
+                "shape": "rounded",
+                "corner_radius": 5.0,
+            }
+        )
+    elif widget_type == "hat":
+        style.update({"indicator_size": 12.0, "show_label": False, "show_axis_labels": True, "hat_positions": 4})
+    elif widget_type == "label":
+        style.update(
+            {
+                "fill": "#00000000",
+                "border": "#ff2a2a",
+                "border_width": 0.0,
+                "corner_radius": 4.0,
+                "font_size": 13,
+                "show_label": True,
+            }
+        )
+    elif widget_type in ("shape", "panel"):
+        style.update(
+            {
+                "fill": "#101820",
+                "border": "#1e2a3a",
+                "border_width": 2.0,
+                "corner_radius": 18.0,
+                "opacity": 0.92,
+                "show_label": False,
+                "shape_kind": "rectangle",
+                "shape_closed": True,
+            }
+        )
+    elif widget_type == "image":
+        style.update(
+            {
+                "fill": "#00000000",
+                "border": "#1e2a3a",
+                "border_width": 0.0,
+                "opacity": 1.0,
+                "show_label": False,
+                "image_path": "",
+                "image_keep_aspect": True,
+            }
+        )
+    elif widget_type == "streamdeck":
+        style.update(
+            {
+                "fill": "#1a1d22",
+                "border": "#3a414c",
+                "border_width": 2.0,
+                "corner_radius": 14.0,
+                "opacity": 1.0,
+                "show_label": False,
+                "streamdeck_device_id": "",
+                "streamdeck_follow_page": True,
+                "streamdeck_page": 1,
+                "show_bezel": True,
+            }
+        )
+    return style
+
+
+def _refresh_font_scale_base(item: dict[str, Any], style_updates: dict[str, Any] | None = None):
+    """Remember the widget size that the current font size was chosen at."""
+    style = item.get("style") or {}
+    if not style.get("auto_scale_font"):
+        return
+    updates = style_updates or {}
+    if "font_scale_base" in updates:
+        return
+    if not (
+        "auto_scale_font" in updates
+        or "font_size" in updates
+        or "axis_label_font_size" in updates
+        or not style.get("font_scale_base")
+    ):
+        return
+    style["font_scale_base"] = min(max(1, int(item.get("w") or 1)), max(1, int(item.get("h") or 1)))
+
+
+OVERLAY_CONFIG_KEY = "obs_overlay"
+XY_WIDGET_TYPES = ("axis_stick_square", "axis_stick_circle", "axis_crosshair")
+NO_CORNER_RADIUS_TYPES = (
+    "axis_radio",
+    "axis_radial",
+    "axis_dial",
+    "axis_encoder",
+    "axis_crosshair",
+    "axis_stick_circle",
+)
+SINGLE_AXIS_TYPES = (
+    "axis_bar",
+    "axis_radio",
+    "axis_fader",
+    "axis_radial",
+    "axis_encoder",
+    "axis_dial",
+)
+
+
+def widget_binding_kind(widget_type: str) -> str:
+    if widget_type in XY_WIDGET_TYPES:
+        return "xy"
+    if widget_type == "button":
+        return "button"
+    if widget_type == "hat":
+        return "hat"
+    if widget_type in ("label", "panel", "shape", "image", "streamdeck"):
+        return "none"
+    if widget_type in SINGLE_AXIS_TYPES or str(widget_type).startswith("axis"):
+        return "axis"
+    return "none"
+
+
+def default_binding(axis_id: int = 1) -> dict[str, Any]:
+    return {
+        "source": "physical",
+        "device_guid": "",
+        "device_name": "",
+        "vjoy_id": 0,
+        "input_type": "axis",
+        "input_id": int(axis_id),
+        "state_name": "",
+        "invert": False,
+    }
+
+
+def default_toggle_binding() -> dict[str, Any]:
+    binding = default_binding(1)
+    binding["input_type"] = "button"
+    binding["input_id"] = 0
+    return binding
+
+
+def normalize_toggle_binding(raw) -> dict[str, Any]:
+    binding = default_toggle_binding()
+    if isinstance(raw, dict):
+        binding.update(raw)
+    kind = str(binding.get("input_type") or "button").casefold()
+    binding["input_type"] = kind if kind in ("axis", "button", "hat", "state") else "button"
+    try:
+        binding["input_id"] = int(binding.get("input_id") or 0)
+    except (TypeError, ValueError):
+        binding["input_id"] = 0
+    binding["invert"] = bool(binding.get("invert"))
+    return binding
+
+
+def default_canvas() -> dict[str, Any]:
+    return {
+        "width": 1280,
+        "height": 720,
+        "background_mode": "chroma",
+        "chroma_color": "#00FF00",
+        "image_path": "",
+        "grid_size": 8,
+        "snap_to_grid": True,
+        "always_on_top": False,
+        "frameless": False,
+        "show_drag_bar": True,
+        "show_on_profile_start": False,
+        "interactive": False,
+        "toggle_binding": default_toggle_binding(),
+        "monitor_index": 0,
+        "monitor_name": "",
+        "capture_width": 1280,
+        "capture_height": 720,
+        "guides": [],
+    }
+
+
+def default_page(name: str = "Overlay") -> dict[str, Any]:
+    return {
+        "id": _new_id(),
+        "name": str(name).strip() or "Overlay",
+        "visible": True,
+        "window_x": None,
+        "window_y": None,
+        "canvas": default_canvas(),
+        "widgets": [],
+    }
+
+
+DEFAULT_GUIDE_COLOR = "#c44cff"
+
+
+def normalize_guides(canvas: dict[str, Any] | None) -> list[dict[str, Any]]:
+    canvas = canvas if isinstance(canvas, dict) else {}
+    guides = []
+    for raw in canvas.get("guides") or []:
+        if not isinstance(raw, dict):
+            continue
+        axis = str(raw.get("axis") or "v").casefold()
+        axis = "h" if axis.startswith("h") else "v"
+        try:
+            pos = float(raw.get("position") if raw.get("position") is not None else 0.5)
+        except (TypeError, ValueError):
+            pos = 0.5
+        if pos > 1.0:
+            pos = pos / 100.0
+        pos = max(0.0, min(1.0, pos))
+        color = str(raw.get("color") or DEFAULT_GUIDE_COLOR)
+        gid = str(raw.get("id") or "") or _new_id()
+        guides.append({"id": gid, "axis": axis, "position": pos, "color": color})
+    canvas["guides"] = guides
+    return guides
+
+
+def normalize_background_mode(value) -> str:
+    mode = str(value or "chroma").casefold().replace("_", "-").replace(" ", "-")
+    if mode in ("onscreen", "on-screen"):
+        return "onscreen"
+    if mode == "image":
+        return "image"
+    return "chroma"
+
+
+def is_onscreen_mode(canvas: dict[str, Any] | None) -> bool:
+    return normalize_background_mode((canvas or {}).get("background_mode")) == "onscreen"
+
+
+def is_interactive_overlay(canvas: dict[str, Any] | None) -> bool:
+    return bool((canvas or {}).get("interactive"))
+
+
+def canonical_widget_type(widget_type: str) -> str:
+    if widget_type == "panel":
+        return "shape"
+    if widget_type == "axis_dial":
+        return "axis_radial"
+    return widget_type or "button"
+
+
+def new_widget(widget_type: str, x: int = 40, y: int = 40) -> dict[str, Any]:
+    widget_type = canonical_widget_type(widget_type)
+    if widget_type not in WIDGET_TYPES:
+        widget_type = "button"
+    w, h = DEFAULT_SIZES[widget_type]
+    item = {
+        "id": _new_id(),
+        "type": widget_type,
+        "x": int(x),
+        "y": int(y),
+        "w": int(w),
+        "h": int(h),
+        "z": 0,
+        "rotation": 0,
+        "label": DEFAULT_LABELS.get(widget_type, ""),
+        "visible": True,
+        "group": "",
+        "style": default_style(widget_type),
+        "binding": default_binding(1),
+        "binding_y": default_binding(2),
+        "points": [],
+    }
+    if widget_type == "shape":
+        from .shapes import default_shape_points, normalize_shape_kind
+
+        kind = normalize_shape_kind(item["style"].get("shape_kind"))
+        item["points"] = default_shape_points(kind)
+    return item
+
+
+def profile_xml_path(profile=None) -> str | None:
+    profile = profile or gremlin.shared_state.current_profile
+    if profile is None:
+        return None
+    return getattr(profile, "profile_file", None) or getattr(profile, "_profile_fname", None)
+
+
+def profile_display_name(profile=None) -> str:
+    profile = profile or gremlin.shared_state.current_profile
+    if profile is None:
+        return "No profile"
+    name = getattr(profile, "name", None) or getattr(profile, "_profile_name", None)
+    if name:
+        return str(name)
+    path = profile_xml_path(profile)
+    if path:
+        return os.path.splitext(os.path.basename(path))[0]
+    return "Unsaved profile"
+
+
+def overlay_path_for_profile(profile=None) -> str | None:
+    """Optional sidecar JSON next to the profile XML (fallback / export)."""
+    fname = profile_xml_path(profile)
+    if not fname:
+        return None
+    return gremlin.util.swap_ext(fname, "overlay.json")
+
+
+def _same_profile_path(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    try:
+        return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+    except Exception:
+        return str(left).casefold() == str(right).casefold()
+
+
+class OverlayScene(QtCore.QObject):
+    """Versioned overlay layout: pages of canvas + widgets. canvas/widgets alias the active page."""
+
+    changed = Signal()
+    selection_changed = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.pages: list[dict[str, Any]] = []
+        self.active_page_id: str | None = None
+        self.canvas: dict[str, Any] = {}
+        self.widgets: list[dict[str, Any]] = []
+        self.selected_ids: list[str] = []
+        self._undo: list[str] = []
+        self._redo: list[str] = []
+        self._suspend = 0
+        self._path: str | None = None
+        self._profile_key: str | None = None
+        self._dirty = False
+        self._sorted_cache: list[dict[str, Any]] | None = None
+        self._reset_default_pages(emit=False)
+
+    def _reset_default_pages(self, emit: bool = True):
+        page = default_page("Overlay")
+        self.pages = [page]
+        self.active_page_id = page["id"]
+        self._sync_active_aliases()
+        self.selected_ids = []
+        if emit:
+            self._emit()
+            self.selection_changed.emit()
+
+    def _sync_active_aliases(self):
+        page = self.active_page()
+        if page is None:
+            page = default_page("Overlay")
+            self.pages = [page]
+            self.active_page_id = page["id"]
+        self.canvas = page["canvas"]
+        self.widgets = page["widgets"]
+        self._sorted_cache = None
+
+    def _set_active_widgets(self, widgets: list[dict[str, Any]]):
+        page = self.active_page()
+        if page is None:
+            self.widgets = widgets
+            return
+        page["widgets"] = widgets
+        self.widgets = widgets
+
+    def _normalize_canvas(self, raw) -> dict[str, Any]:
+        canvas = default_canvas()
+        if isinstance(raw, dict):
+            canvas.update(raw)
+        canvas["background_mode"] = normalize_background_mode(canvas.get("background_mode"))
+        canvas["toggle_binding"] = normalize_toggle_binding(canvas.get("toggle_binding"))
+        normalize_guides(canvas)
+        return canvas
+
+    def _normalize_page(self, raw) -> dict[str, Any]:
+        page = default_page()
+        data = raw if isinstance(raw, dict) else {}
+        page_id = str(data.get("id") or "").strip()
+        if page_id:
+            page["id"] = page_id
+        name = str(data.get("name") or "").strip()
+        if name:
+            page["name"] = name
+        page["visible"] = bool(data.get("visible", True))
+        page["window_x"] = _optional_int(data.get("window_x"))
+        page["window_y"] = _optional_int(data.get("window_y"))
+        page["canvas"] = self._normalize_canvas(data.get("canvas"))
+        page["widgets"] = [self._normalize_widget(item) for item in data.get("widgets") or [] if isinstance(item, dict)]
+        return page
+
+    def _legacy_page(self, data: dict[str, Any]) -> dict[str, Any]:
+        page = default_page("Overlay")
+        page["canvas"] = self._normalize_canvas(data.get("canvas"))
+        page["widgets"] = [self._normalize_widget(item) for item in data.get("widgets") or [] if isinstance(item, dict)]
+        page["visible"] = bool(data.get("visible", True))
+        page["window_x"] = _optional_int(data.get("window_x"))
+        page["window_y"] = _optional_int(data.get("window_y"))
+        return page
+
+    def page_by_id(self, page_id: str | None) -> dict[str, Any] | None:
+        if not page_id:
+            return None
+        for page in self.pages:
+            if page.get("id") == page_id:
+                return page
+        return None
+
+    def active_page(self) -> dict[str, Any] | None:
+        page = self.page_by_id(self.active_page_id)
+        if page is not None:
+            return page
+        return self.pages[0] if self.pages else None
+
+    def canvas_for(self, page_id: str | None = None) -> dict[str, Any]:
+        page = self.page_by_id(page_id) if page_id else self.active_page()
+        if page is None:
+            if page_id:
+                return default_canvas()
+            return self.canvas if isinstance(self.canvas, dict) else default_canvas()
+        return page["canvas"]
+
+    def widgets_for(self, page_id: str | None = None) -> list[dict[str, Any]]:
+        page = self.page_by_id(page_id) if page_id else self.active_page()
+        if page is None:
+            return [] if page_id else self.widgets
+        return page["widgets"]
+
+    def set_active_page(self, page_id: str | None, emit: bool = True) -> bool:
+        page = self.page_by_id(page_id)
+        if page is None:
+            return False
+        if self.active_page_id == page["id"] and self.canvas is page["canvas"] and self.widgets is page["widgets"]:
+            return False
+        self.active_page_id = page["id"]
+        self._sync_active_aliases()
+        self.selected_ids = []
+        if emit:
+            self._emit()
+            self.selection_changed.emit()
+        return True
+
+    def _unique_page_name(self, base: str) -> str:
+        base = str(base).strip() or "Page"
+        names = {str(page.get("name") or "") for page in self.pages}
+        if base not in names:
+            return base
+        index = 2
+        while f"{base} {index}" in names:
+            index += 1
+        return f"{base} {index}"
+
+    def add_page(self, name: str | None = None, activate: bool = True) -> dict[str, Any]:
+        self.push_undo()
+        page = default_page(self._unique_page_name(name or "Page"))
+        self.pages.append(page)
+        self._dirty = True
+        if activate:
+            self.set_active_page(page["id"], emit=True)
+        else:
+            self._emit()
+        return page
+
+    def duplicate_page(self, page_id: str | None = None, activate: bool = True) -> dict[str, Any] | None:
+        src = self.page_by_id(page_id) or self.active_page()
+        if src is None:
+            return None
+        self.push_undo()
+        page = copy.deepcopy(src)
+        page["id"] = _new_id()
+        page["name"] = self._unique_page_name(f"{src.get('name') or 'Page'} copy")
+        page["window_x"] = None
+        page["window_y"] = None
+        group_map: dict[str, str] = {}
+        for item in page.get("widgets") or []:
+            item["id"] = _new_id()
+            old_group = str(item.get("group") or "").strip()
+            if old_group:
+                item["group"] = group_map.setdefault(old_group, _new_id())
+        self.pages.append(page)
+        self._dirty = True
+        if activate:
+            self.set_active_page(page["id"], emit=True)
+        else:
+            self._emit()
+        return page
+
+    def delete_page(self, page_id: str | None = None) -> bool:
+        if len(self.pages) <= 1:
+            return False
+        page = self.page_by_id(page_id) or self.active_page()
+        if page is None:
+            return False
+        index = self.pages.index(page)
+        self.push_undo()
+        self.pages = [item for item in self.pages if item is not page]
+        neighbor = self.pages[min(index, len(self.pages) - 1)]
+        self.active_page_id = neighbor["id"]
+        self._sync_active_aliases()
+        self.selected_ids = []
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+        return True
+
+    def reorder_pages(self, page_ids: list[str]) -> bool:
+        by_id = {page["id"]: page for page in self.pages}
+        ordered = [by_id[page_id] for page_id in page_ids if page_id in by_id]
+        for page in self.pages:
+            if page not in ordered:
+                ordered.append(page)
+        if [page["id"] for page in ordered] == [page["id"] for page in self.pages]:
+            return False
+        self.push_undo()
+        self.pages = ordered
+        self._dirty = True
+        self._emit()
+        return True
+
+    def rename_page(self, name: str, page_id: str | None = None) -> bool:
+        page = self.page_by_id(page_id) or self.active_page()
+        if page is None:
+            return False
+        label = str(name).strip() or page.get("name") or "Overlay"
+        if page.get("name") == label:
+            return False
+        page["name"] = label
+        self._dirty = True
+        self._emit()
+        return True
+
+    def set_page_visible(self, visible: bool, page_id: str | None = None) -> bool:
+        page = self.page_by_id(page_id) or self.active_page()
+        if page is None:
+            return False
+        flag = bool(visible)
+        if bool(page.get("visible", True)) == flag:
+            return False
+        page["visible"] = flag
+        self._dirty = True
+        self._emit()
+        return True
+
+    def record_page_position(self, x: int, y: int, page_id: str | None = None, emit: bool = False):
+        page = self.page_by_id(page_id) or self.active_page()
+        if page is None:
+            return
+        xi, yi = int(x), int(y)
+        if page.get("window_x") == xi and page.get("window_y") == yi:
+            return
+        page["window_x"] = xi
+        page["window_y"] = yi
+        self._dirty = True
+        if emit:
+            self._emit()
+
+    def reset_page_position(self, page_id: str | None = None, emit: bool = True):
+        page = self.page_by_id(page_id) or self.active_page()
+        if page is None:
+            return
+        page["window_x"] = None
+        page["window_y"] = None
+        canvas = page.get("canvas") if isinstance(page.get("canvas"), dict) else None
+        if canvas is not None and is_onscreen_mode(canvas):
+            canvas["monitor_index"] = 0
+            canvas["monitor_name"] = ""
+        self._dirty = True
+        if emit:
+            self._emit()
+
+    def to_dict(self) -> dict[str, Any]:
+        self._sync_active_aliases()
+        return {
+            "version": SCENE_VERSION,
+            "active_page_id": self.active_page_id,
+            "pages": copy.deepcopy(self.pages),
+        }
+
+    def from_dict(self, data: dict[str, Any] | None):
+        data = data or {}
+        raw_pages = data.get("pages")
+        if isinstance(raw_pages, list) and raw_pages:
+            pages = [self._normalize_page(raw) for raw in raw_pages]
+        elif data.get("canvas") is not None or data.get("widgets") is not None:
+            pages = [self._legacy_page(data)]
+        else:
+            pages = [default_page("Overlay")]
+        seen: set[str] = set()
+        for page in pages:
+            pid = str(page.get("id") or "")
+            if not pid or pid in seen:
+                page["id"] = _new_id()
+            seen.add(page["id"])
+        self.pages = pages or [default_page("Overlay")]
+        active = data.get("active_page_id")
+        if not self.page_by_id(active):
+            active = self.pages[0]["id"]
+        self.active_page_id = active
+        self._sync_active_aliases()
+        self.selected_ids = [wid for wid in self.selected_ids if self.widget_by_id(wid)]
+        self._emit()
+        self.selection_changed.emit()
+
+    def _normalize_widget(self, raw: dict[str, Any]) -> dict[str, Any]:
+        from .shapes import default_shape_points, normalize_shape_kind, normalize_shape_points
+
+        widget_type = canonical_widget_type(raw.get("type", "button"))
+        item = new_widget(widget_type)
+        item.update({k: raw[k] for k in item.keys() if k in raw and k not in ("style", "binding", "binding_y", "points")})
+        style = default_style(widget_type)
+        style.update(raw.get("style") or {})
+        item["style"] = style
+        item["binding"], item["binding_y"] = self._normalize_bindings(widget_type, raw)
+        if widget_type == "shape":
+            kind = normalize_shape_kind(style.get("shape_kind"))
+            style["shape_kind"] = kind
+            raw_points = raw.get("points")
+            item["points"] = normalize_shape_points(raw_points, kind) if raw_points else default_shape_points(kind)
+        if not item.get("id"):
+            item["id"] = _new_id()
+        return item
+
+    def _normalize_bindings(self, widget_type: str, raw: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+        raw_x = dict(raw.get("binding") or {})
+        raw_y = raw.get("binding_y")
+        x = default_binding(1)
+        x.update(raw_x)
+        legacy_y_id = x.pop("input_id_y", None)
+        legacy_y_inv = x.pop("invert_y", None)
+        y = default_binding(2)
+        if isinstance(raw_y, dict) and raw_y:
+            y.update(raw_y)
+            y.pop("input_id_y", None)
+            y.pop("invert_y", None)
+        elif widget_type in XY_WIDGET_TYPES:
+            for key in ("source", "device_guid", "device_name", "vjoy_id", "state_name"):
+                if x.get(key) not in (None, ""):
+                    y[key] = x.get(key)
+            y["input_type"] = "axis"
+            y["input_id"] = int(legacy_y_id or y.get("input_id") or 2)
+            y["invert"] = bool(legacy_y_inv)
+        return x, y
+
+    def snapshot(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    def restore_snapshot(self, blob: str):
+        self.from_dict(json.loads(blob))
+        self._dirty = True
+
+    def push_undo(self):
+        self._undo.append(self.snapshot())
+        if len(self._undo) > 60:
+            self._undo = self._undo[-60:]
+        self._redo.clear()
+
+    def undo(self):
+        if not self._undo:
+            return
+        self._redo.append(self.snapshot())
+        self.restore_snapshot(self._undo.pop())
+
+    def redo(self):
+        if not self._redo:
+            return
+        self._undo.append(self.snapshot())
+        self.restore_snapshot(self._redo.pop())
+
+    def _emit(self):
+        self._sorted_cache = None
+        if self._suspend <= 0:
+            self.changed.emit()
+
+    def begin_edit(self):
+        self.push_undo()
+        self._suspend += 1
+
+    def end_edit(self):
+        self._suspend = max(0, self._suspend - 1)
+        self._dirty = True
+        self._emit()
+
+    def widget_by_id(self, widget_id: str, page_id: str | None = None) -> dict[str, Any] | None:
+        for item in self.widgets_for(page_id):
+            if item["id"] == widget_id:
+                return item
+        return None
+
+    def sorted_widgets(self, page_id: str | None = None) -> list[dict[str, Any]]:
+        widgets = self.widgets_for(page_id)
+        if page_id in (None, self.active_page_id):
+            if self._sorted_cache is None:
+                order = {id(widget): index for index, widget in enumerate(widgets)}
+                self._sorted_cache = sorted(widgets, key=lambda w: (w.get("z", 0), order.get(id(w), 0)))
+            return self._sorted_cache
+        order = {id(widget): index for index, widget in enumerate(widgets)}
+        return sorted(widgets, key=lambda w: (w.get("z", 0), order.get(id(w), 0)))
+
+    def add_widget(self, widget_type: str, x: int = 40, y: int = 40, push_undo: bool = True) -> dict[str, Any]:
+        if push_undo:
+            self.push_undo()
+        item = new_widget(widget_type, x, y)
+        item["z"] = (max((w.get("z", 0) for w in self.widgets), default=-1) + 1)
+        if self.canvas.get("snap_to_grid"):
+            grid = max(1, int(self.canvas.get("grid_size", 8)))
+            item["x"] = int(round(item["x"] / grid) * grid)
+            item["y"] = int(round(item["y"] / grid) * grid)
+        self.widgets.append(item)
+        self.selected_ids = [item["id"]]
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+        return item
+
+    def convert_selected(self, widget_type: str) -> bool:
+        """Change selected widgets to another type, keeping compatible settings.
+
+        Returns False when nothing is selected so the caller can add a new widget.
+        """
+        widget_type = canonical_widget_type(widget_type)
+        if widget_type not in WIDGET_TYPES:
+            widget_type = "button"
+        selected = self.selected_widgets()
+        if not selected:
+            return False
+        if all(item.get("type") == widget_type for item in selected):
+            return False
+        self.push_undo()
+        self._suspend += 1
+        try:
+            for item in selected:
+                self._convert_widget(item, widget_type)
+        finally:
+            self._suspend = max(0, self._suspend - 1)
+            self._dirty = True
+            self._emit()
+            self.selection_changed.emit()
+        return True
+
+    def _convert_widget(self, item: dict[str, Any], widget_type: str):
+        old_type = item.get("type") or "button"
+        if old_type == widget_type:
+            return
+        old_style = dict(item.get("style") or {})
+        new_style = default_style(widget_type)
+        new_style.update(old_style)
+        old_size = DEFAULT_SIZES.get(old_type)
+        new_size = DEFAULT_SIZES.get(widget_type)
+        if old_size and new_size and (int(item.get("w") or 0), int(item.get("h") or 0)) == tuple(int(v) for v in old_size):
+            item["w"], item["h"] = int(new_size[0]), int(new_size[1])
+        item["type"] = widget_type
+        item["style"] = new_style
+        if widget_type == "shape":
+            from .shapes import default_shape_points, normalize_shape_kind
+
+            kind = normalize_shape_kind(new_style.get("shape_kind"))
+            new_style["shape_kind"] = kind
+            if not item.get("points"):
+                item["points"] = default_shape_points(kind)
+        old_kind = widget_binding_kind(old_type)
+        new_kind = widget_binding_kind(widget_type)
+        if new_kind == "none" or old_kind == new_kind:
+            return
+        if {old_kind, new_kind} <= {"axis", "xy"}:
+            binding = item.get("binding") or default_binding(1)
+            if binding.get("input_type") != "axis":
+                item["binding"] = default_binding(1)
+            if new_kind == "xy":
+                y = item.get("binding_y")
+                if not isinstance(y, dict) or not y:
+                    item["binding_y"] = default_binding(2)
+            return
+        item["binding"] = default_binding(1)
+        item["binding_y"] = default_binding(2)
+        if new_kind == "button":
+            item["binding"]["input_type"] = "button"
+        elif new_kind == "hat":
+            item["binding"]["input_type"] = "hat"
+
+    def add_widgets(self, items: list[dict[str, Any]], push_undo: bool = True):
+        if push_undo:
+            self.push_undo()
+        ids = []
+        z = max((w.get("z", 0) for w in self.widgets), default=-1)
+        for raw in items:
+            item = self._normalize_widget(raw)
+            item["id"] = _new_id()
+            z += 1
+            item["z"] = z
+            self.widgets.append(item)
+            ids.append(item["id"])
+        self.selected_ids = ids
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+
+    def remove_selected(self):
+        if not self.selected_ids:
+            return
+        self.push_undo()
+        ids = set(self.selected_ids)
+        self._set_active_widgets([w for w in self.widgets if w["id"] not in ids])
+        self.selected_ids = []
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+
+    def clear_widgets(self):
+        if not self.widgets:
+            return
+        self.push_undo()
+        self._set_active_widgets([])
+        self.selected_ids = []
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+
+    def duplicate_selected(self):
+        if not self.selected_ids:
+            return
+        self.push_undo()
+        copies = []
+        group_map: dict[str, str] = {}
+        grid = max(1, int(self.canvas.get("grid_size", 8)))
+        for widget_id in list(self.selected_ids):
+            src = self.widget_by_id(widget_id)
+            if not src:
+                continue
+            item = copy.deepcopy(src)
+            item["id"] = _new_id()
+            item["x"] = int(item["x"]) + grid * 2
+            item["y"] = int(item["y"]) + grid * 2
+            item["z"] = (max((w.get("z", 0) for w in self.widgets), default=0) + 1)
+            old_group = str(item.get("group") or "").strip()
+            if old_group:
+                item["group"] = group_map.setdefault(old_group, _new_id())
+            self.widgets.append(item)
+            copies.append(item["id"])
+        self.selected_ids = copies
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+
+    def expand_group_ids(self, ids: list[str]) -> list[str]:
+        """Include every widget that shares a group with any of the given ids."""
+        seen: list[str] = []
+        idset: set[str] = set()
+        groups: set[str] = set()
+        for widget_id in ids:
+            if widget_id in idset:
+                continue
+            item = self.widget_by_id(widget_id)
+            if not item:
+                continue
+            seen.append(widget_id)
+            idset.add(widget_id)
+            group = str(item.get("group") or "").strip()
+            if group:
+                groups.add(group)
+        if not groups:
+            return seen
+        for item in self.widgets:
+            group = str(item.get("group") or "").strip()
+            if group in groups and item["id"] not in idset:
+                seen.append(item["id"])
+                idset.add(item["id"])
+        return seen
+
+    def group_selected(self) -> bool:
+        ids = list(self.selected_ids)
+        if len(ids) < 2:
+            return False
+        self.push_undo()
+        gid = _new_id()
+        for widget_id in ids:
+            item = self.widget_by_id(widget_id)
+            if item:
+                item["group"] = gid
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+        return True
+
+    def ungroup_selected(self):
+        ids = self.expand_group_ids(list(self.selected_ids))
+        if not ids:
+            return
+        self.push_undo()
+        for widget_id in ids:
+            item = self.widget_by_id(widget_id)
+            if item:
+                item["group"] = ""
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+
+    def set_selection(self, ids: list[str], additive: bool = False):
+        ids = [i for i in ids if self.widget_by_id(i)]
+        if additive:
+            merged = list(self.selected_ids)
+            for i in ids:
+                if i in merged:
+                    merged.remove(i)
+                else:
+                    merged.append(i)
+            self.selected_ids = merged
+        else:
+            self.selected_ids = ids
+        self.selection_changed.emit()
+
+    def primary_selection(self) -> dict[str, Any] | None:
+        if not self.selected_ids:
+            return None
+        return self.widget_by_id(self.selected_ids[-1])
+
+    def bring_forward(self):
+        self._shift_z_order(1)
+
+    def send_backward(self):
+        self._shift_z_order(-1)
+
+    def _shift_z_order(self, delta: int):
+        """Move selected widgets one paint-order step without hopping other selected items."""
+        if not self.selected_ids:
+            return
+        selected = set(self.selected_ids)
+        ordered = self.sorted_widgets()
+        if len(ordered) < 2:
+            return
+        moved = False
+        if delta > 0:
+            for i in range(len(ordered) - 2, -1, -1):
+                if ordered[i]["id"] in selected and ordered[i + 1]["id"] not in selected:
+                    ordered[i], ordered[i + 1] = ordered[i + 1], ordered[i]
+                    moved = True
+        else:
+            for i in range(1, len(ordered)):
+                if ordered[i]["id"] in selected and ordered[i - 1]["id"] not in selected:
+                    ordered[i], ordered[i - 1] = ordered[i - 1], ordered[i]
+                    moved = True
+        if not moved:
+            return
+        self.push_undo()
+        for z, item in enumerate(ordered):
+            item["z"] = z
+        self._set_active_widgets(ordered)
+        self._dirty = True
+        self._emit()
+        self.selection_changed.emit()
+
+    def hit_test(self, x: float, y: float, page_id: str | None = None) -> dict[str, Any] | None:
+        for item in reversed(self.sorted_widgets(page_id)):
+            if not item.get("visible", True):
+                continue
+            if item["x"] <= x <= item["x"] + item["w"] and item["y"] <= y <= item["y"] + item["h"]:
+                return item
+        return None
+
+    def widgets_in_rect(self, x: float, y: float, w: float, h: float) -> list[str]:
+        x2, y2 = x + w, y + h
+        x, x2 = min(x, x2), max(x, x2)
+        y, y2 = min(y, y2), max(y, y2)
+        ids = []
+        for item in self.widgets:
+            ix, iy, iw, ih = item["x"], item["y"], item["w"], item["h"]
+            if ix + iw >= x and ix <= x2 and iy + ih >= y and iy <= y2:
+                ids.append(item["id"])
+        return ids
+
+    def snap_value(self, value: float) -> int:
+        if not self.canvas.get("snap_to_grid"):
+            return int(round(value))
+        grid = max(1, int(self.canvas.get("grid_size", 8)))
+        return int(round(value / grid) * grid)
+
+    def guide_by_id(self, guide_id: str) -> dict[str, Any] | None:
+        for guide in self.canvas.get("guides") or []:
+            if guide.get("id") == guide_id:
+                return guide
+        return None
+
+    def add_guide(self, axis: str, position: float = 0.5, color: str | None = None) -> dict[str, Any]:
+        self.push_undo()
+        axis = "h" if str(axis).casefold().startswith("h") else "v"
+        pos = max(0.0, min(1.0, float(position)))
+        existing = [float(g.get("position") or 0) for g in (self.canvas.get("guides") or []) if g.get("axis") == axis]
+        if any(abs(pos - other) < 0.005 for other in existing):
+            for candidate in (0.25, 0.75, 0.33, 0.67, 0.1, 0.9, 0.4, 0.6):
+                if not any(abs(candidate - other) < 0.005 for other in existing):
+                    pos = candidate
+                    break
+        guide = {
+            "id": _new_id(),
+            "axis": axis,
+            "position": pos,
+            "color": color or DEFAULT_GUIDE_COLOR,
+        }
+        self.canvas.setdefault("guides", []).append(guide)
+        self._dirty = True
+        self._emit()
+        return guide
+
+    def remove_guide(self, guide_id: str):
+        guides = list(self.canvas.get("guides") or [])
+        next_guides = [g for g in guides if g.get("id") != guide_id]
+        if len(next_guides) == len(guides):
+            return
+        self.push_undo()
+        self.canvas["guides"] = next_guides
+        self._dirty = True
+        self._emit()
+
+    def update_guide(self, guide_id: str, **fields):
+        guide = self.guide_by_id(guide_id)
+        if not guide:
+            return
+        if "position" in fields:
+            try:
+                pos = float(fields["position"])
+            except (TypeError, ValueError):
+                pos = float(guide.get("position") or 0.5)
+            if pos > 1.0:
+                pos = pos / 100.0
+            guide["position"] = max(0.0, min(1.0, pos))
+        if "color" in fields and fields["color"]:
+            guide["color"] = str(fields["color"])
+        if "axis" in fields:
+            axis = str(fields["axis"]).casefold()
+            guide["axis"] = "h" if axis.startswith("h") else "v"
+        self._dirty = True
+        self._emit()
+
+    def snap_geom_to_guides(
+        self,
+        x: float,
+        y: float,
+        w: float,
+        h: float,
+        x_edges: tuple[str, ...] | None = None,
+        y_edges: tuple[str, ...] | None = None,
+        mode: str = "move",
+    ) -> tuple[float, float, float, float]:
+        guides = self.canvas.get("guides") or []
+        if not guides:
+            return x, y, w, h
+        cw = max(1.0, float(self.canvas.get("width") or 1280))
+        ch = max(1.0, float(self.canvas.get("height") or 720))
+        threshold = float(max(8, int(self.canvas.get("grid_size") or 8)))
+        if x_edges is None:
+            x_edges = ("left", "center", "right")
+        if y_edges is None:
+            y_edges = ("top", "center", "bottom")
+        vertical = [float(g.get("position") or 0) * cw for g in guides if g.get("axis") == "v"]
+        horizontal = [float(g.get("position") or 0) * ch for g in guides if g.get("axis") == "h"]
+
+        def _best(current: dict[str, float], targets: list[float]):
+            best_dist = threshold + 1.0
+            best = None
+            for name, value in current.items():
+                for target in targets:
+                    dist = abs(value - target)
+                    if dist < best_dist:
+                        best_dist = dist
+                        best = (name, target)
+            return best
+
+        x_map = {}
+        if "left" in x_edges:
+            x_map["left"] = x
+        if "center" in x_edges:
+            x_map["center"] = x + w / 2.0
+        if "right" in x_edges:
+            x_map["right"] = x + w
+        hit = _best(x_map, vertical) if vertical else None
+        if hit:
+            edge, target = hit
+            if mode == "resize":
+                if edge == "left":
+                    right = x + w
+                    x = target
+                    w = max(8.0, right - x)
+                elif edge == "right":
+                    w = max(8.0, target - x)
+                elif edge == "center":
+                    x = target - w / 2.0
+            else:
+                if edge == "left":
+                    x = target
+                elif edge == "right":
+                    x = target - w
+                else:
+                    x = target - w / 2.0
+
+        y_map = {}
+        if "top" in y_edges:
+            y_map["top"] = y
+        if "center" in y_edges:
+            y_map["center"] = y + h / 2.0
+        if "bottom" in y_edges:
+            y_map["bottom"] = y + h
+        hit = _best(y_map, horizontal) if horizontal else None
+        if hit:
+            edge, target = hit
+            if mode == "resize":
+                if edge == "top":
+                    bottom = y + h
+                    y = target
+                    h = max(8.0, bottom - y)
+                elif edge == "bottom":
+                    h = max(8.0, target - y)
+                elif edge == "center":
+                    y = target - h / 2.0
+            else:
+                if edge == "top":
+                    y = target
+                elif edge == "bottom":
+                    y = target - h
+                else:
+                    y = target - h / 2.0
+        return x, y, w, h
+
+    def snap_selection_to_guides(self):
+        primary = self.primary_selection()
+        if not primary:
+            return
+        nx, ny, nw, nh = self.snap_geom_to_guides(
+            float(primary["x"]),
+            float(primary["y"]),
+            float(primary["w"]),
+            float(primary["h"]),
+            mode="move",
+        )
+        dx = int(round(nx - float(primary["x"])))
+        dy = int(round(ny - float(primary["y"])))
+        if dx == 0 and dy == 0:
+            return
+        for widget_id in self.selected_ids:
+            item = self.widget_by_id(widget_id)
+            if not item:
+                continue
+            item["x"] = int(item["x"]) + dx
+            item["y"] = int(item["y"]) + dy
+
+    def move_selected(self, dx: int, dy: int, snap: bool = True):
+        if not self.selected_ids:
+            return
+        for widget_id in self.selected_ids:
+            item = self.widget_by_id(widget_id)
+            if not item:
+                continue
+            nx = item["x"] + dx
+            ny = item["y"] + dy
+            item["x"] = self.snap_value(nx) if snap else int(nx)
+            item["y"] = self.snap_value(ny) if snap else int(ny)
+        if snap:
+            self.snap_selection_to_guides()
+        self._dirty = True
+        self._emit()
+
+    def apply_widget_update(self, widget_id: str, **fields):
+        item = self.widget_by_id(widget_id)
+        if not item:
+            return
+        for key, value in fields.items():
+            if key == "style":
+                item["style"].update(value)
+                _refresh_font_scale_base(item, value)
+            elif key in ("binding", "binding_y"):
+                item.setdefault(key, default_binding()).update(value)
+            else:
+                item[key] = value
+        self._dirty = True
+        self._emit()
+
+    def apply_widget_updates(self, ids: list[str], **fields):
+        ids = [i for i in ids if self.widget_by_id(i)]
+        if not ids:
+            return
+        if len(ids) == 1:
+            self.apply_widget_update(ids[0], **fields)
+            return
+        self._suspend += 1
+        try:
+            for widget_id in ids:
+                self.apply_widget_update(widget_id, **fields)
+        finally:
+            self._suspend = max(0, self._suspend - 1)
+            self._dirty = True
+            self._emit()
+
+    def selected_widgets(self) -> list[dict[str, Any]]:
+        items = []
+        seen = set()
+        for widget_id in self.selected_ids:
+            if widget_id in seen:
+                continue
+            item = self.widget_by_id(widget_id)
+            if item:
+                items.append(item)
+                seen.add(widget_id)
+        return items
+
+    def default_path(self) -> str | None:
+        return overlay_path_for_profile()
+
+    def belongs_to_profile(self, profile=None) -> bool:
+        path = profile_xml_path(profile)
+        if not path:
+            return self._profile_key is None
+        if not self._profile_key:
+            return False
+        return _same_profile_path(self._profile_key, path)
+
+    def load_for_profile(self, profile=None) -> bool:
+        profile = profile or gremlin.shared_state.current_profile
+        self._undo.clear()
+        self._redo.clear()
+        self.selected_ids = []
+        path = profile_xml_path(profile)
+        self._profile_key = path
+        self._path = overlay_path_for_profile(profile)
+        data = None
+        if profile is not None:
+            try:
+                cfg = profile._readConfig() or {}
+                candidate = cfg.get(OVERLAY_CONFIG_KEY)
+                if isinstance(candidate, dict):
+                    data = candidate
+            except Exception as err:
+                syslog.warning(f"OBS OVERLAY: profile overlay read failed: {err}")
+        if data is None and self._path and os.path.isfile(self._path):
+            try:
+                with open(self._path, "r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                if profile is not None and isinstance(data, dict):
+                    try:
+                        profile._setConfig(OVERLAY_CONFIG_KEY, data)
+                    except Exception:
+                        pass
+            except Exception as err:
+                syslog.error(f"OBS OVERLAY: failed to load sidecar {self._path}: {err}")
+                data = None
+        if isinstance(data, dict) and (data.get("pages") or data.get("widgets") or data.get("canvas")):
+            self.from_dict(data)
+            self._dirty = False
+            self._undo.clear()
+            self._redo.clear()
+            return True
+        self._reset_default_pages(emit=True)
+        self._dirty = False
+        return False
+
+    def load(self, path: str) -> bool:
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            self.from_dict(data)
+            self._dirty = True
+            self._undo.clear()
+            self._redo.clear()
+            return True
+        except Exception as err:
+            syslog.error(f"OBS OVERLAY: failed to load layout {path}: {err}")
+            return False
+
+    def save(self, path: str | None = None) -> bool:
+        if path:
+            return self._write_sidecar(path, self.to_dict())
+        return self.save_to_profile()
+
+    def save_owned(self) -> bool:
+        """Persist this scene to the profile it was loaded from, even after a switch."""
+        if not self._profile_key:
+            return False
+        current = profile_xml_path()
+        if current and _same_profile_path(current, self._profile_key):
+            return self.save_to_profile()
+        return self._persist_files(self._profile_key, self.to_dict())
+
+    def save_to_profile(self, profile=None) -> bool:
+        profile = profile or gremlin.shared_state.current_profile
+        path = profile_xml_path(profile)
+        if not path:
+            syslog.warning("OBS OVERLAY: save the GEX profile first so the overlay can be stored with it")
+            return False
+        data = self.to_dict()
+        wrote_config = False
+        if profile is not None:
+            try:
+                profile._setConfig(OVERLAY_CONFIG_KEY, data)
+                wrote_config = True
+            except Exception as err:
+                syslog.error(f"OBS OVERLAY: failed to store overlay in profile config: {err}")
+        sidecar_ok = self._write_sidecar(overlay_path_for_profile(profile) or gremlin.util.swap_ext(path, "overlay.json"), data)
+        if wrote_config or sidecar_ok:
+            self._profile_key = path
+            self._path = overlay_path_for_profile(profile)
+            self._dirty = False
+            return True
+        return False
+
+    def _write_sidecar(self, path: str, data: dict[str, Any]) -> bool:
+        try:
+            folder = os.path.dirname(path)
+            if folder and not os.path.isdir(folder):
+                os.makedirs(folder, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2)
+            return True
+        except Exception as err:
+            syslog.error(f"OBS OVERLAY: failed to save layout {path}: {err}")
+            return False
+
+    def _persist_files(self, profile_xml: str, data: dict[str, Any]) -> bool:
+        config_path = gremlin.util.swap_ext(profile_xml, "json")
+        merged: dict[str, Any] | None = {}
+        if os.path.isfile(config_path):
+            try:
+                with open(config_path, "r", encoding="utf-8") as handle:
+                    loaded = json.load(handle) or {}
+                if not isinstance(loaded, dict):
+                    syslog.error(f"OBS OVERLAY: profile config is not an object: {config_path}")
+                    merged = None
+                else:
+                    merged = loaded
+            except Exception as err:
+                syslog.error(f"OBS OVERLAY: could not merge overlay into {config_path}: {err}")
+                merged = None
+        wrote_config = False
+        if merged is not None:
+            merged[OVERLAY_CONFIG_KEY] = data
+            try:
+                folder = os.path.dirname(config_path)
+                if folder and not os.path.isdir(folder):
+                    os.makedirs(folder, exist_ok=True)
+                with open(config_path, "w", encoding="utf-8") as handle:
+                    json.dump(merged, handle, indent=4, sort_keys=True)
+                wrote_config = True
+            except Exception as err:
+                syslog.error(f"OBS OVERLAY: failed to write profile overlay config {config_path}: {err}")
+        sidecar_ok = self._write_sidecar(gremlin.util.swap_ext(profile_xml, "overlay.json"), data)
+        if wrote_config or sidecar_ok:
+            self._dirty = False
+            return True
+        return False
+
+    @property
+    def dirty(self) -> bool:
+        return self._dirty

--- a/gremlin/ui/obs_overlay/overlay_window.py
+++ b/gremlin/ui/obs_overlay/overlay_window.py
@@ -1,0 +1,1103 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import math
+
+from PySide6 import QtCore, QtGui, QtWidgets
+from shiboken6 import Shiboken
+
+from .bindings import OverlayValueBus, widget_accepts_touch
+from .model import DEFAULT_GUIDE_COLOR, OVERLAY_WINDOW_TITLE, OverlayScene, is_interactive_overlay, is_onscreen_mode, normalize_background_mode, overlay_window_title
+from .touch import OverlayTouchHandler
+from .widgets import chroma_fill_color, live_window_is_layered, paint_background, paint_widget, qcolor, widget_dirty_rect, widget_rect
+
+syslog = logging.getLogger("system")
+
+DESIGNER_OVERFLOW_PAD = 48
+DESIGNER_OVERFLOW_FILL = QtGui.QColor("#151a22")
+DESIGNER_CANVAS_BORDER = QtGui.QColor("#7ec8ff")
+
+
+def _transparent_palette(widget: QtWidgets.QWidget):
+    widget.setAutoFillBackground(False)
+    pal = widget.palette()
+    pal.setColor(QtGui.QPalette.Window, QtGui.QColor(0, 0, 0, 0))
+    pal.setColor(QtGui.QPalette.Base, QtGui.QColor(0, 0, 0, 0))
+    widget.setPalette(pal)
+
+
+def touchable_item_at(scene: OverlayScene, x: float, y: float, page_id: str | None = None):
+    """Topmost overlay widget that may receive touch, or None for pass-through."""
+    for item in reversed(scene.sorted_widgets(page_id)):
+        if not item.get("visible", True):
+            continue
+        try:
+            ix, iy = float(item["x"]), float(item["y"])
+            iw, ih = float(item["w"]), float(item["h"])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if ix <= x <= ix + iw and iy <= y <= iy + ih and widget_accepts_touch(item):
+            return item
+    return None
+
+
+def _screen_point_from_lparam(lparam) -> QtCore.QPoint:
+    import ctypes
+
+    x = ctypes.c_int16(lparam & 0xFFFF).value
+    y = ctypes.c_int16((lparam >> 16) & 0xFFFF).value
+    return QtCore.QPoint(x, y)
+
+
+def _nchittest_passthrough(widget: QtWidgets.QWidget, lparam) -> bool:
+    """True when Interactive is on and the cursor is not on a touchable widget."""
+    scene = getattr(widget, "scene", None)
+    if scene is None:
+        return False
+    page_id = getattr(widget, "page_id", None)
+    canvas = scene.canvas_for(page_id)
+    if not is_interactive_overlay(canvas):
+        return False
+    global_pos = _screen_point_from_lparam(lparam)
+    if isinstance(widget, OverlayWindow):
+        local = widget.mapFromGlobal(global_pos)
+        if widget.drag_bar.isVisible() and widget.drag_bar.geometry().contains(local):
+            return False
+        view = getattr(widget, "view", None)
+        if view is None or not Shiboken.isValid(view):
+            return True
+        vl = view.mapFrom(widget, local)
+        if not view.rect().contains(vl):
+            return True
+        scene_pos = view.map_to_scene(QtCore.QPointF(vl))
+        page_id = getattr(view, "page_id", page_id)
+    else:
+        local = widget.mapFromGlobal(global_pos)
+        if not widget.rect().contains(local):
+            return True
+        scene_pos = widget.map_to_scene(QtCore.QPointF(local))
+    return touchable_item_at(scene, scene_pos.x(), scene_pos.y(), page_id) is None
+
+
+def _handle_nchittest(widget: QtWidgets.QWidget, eventType, message):
+    if sys.platform != "win32":
+        return None
+        et = eventType
+        if not isinstance(et, (bytes, bytearray)):
+            et = bytes(et)
+        if not et.startswith(b"windows_generic_MSG"):
+            return None
+    try:
+        from ctypes import wintypes
+
+        msg = wintypes.MSG.from_address(int(message))
+        if msg.message != 0x0084:
+            return None
+        if _nchittest_passthrough(widget, msg.lParam):
+            return True, -1
+    except Exception:
+        return None
+    return None
+
+
+def _extend_frame_into_client(widget: QtWidgets.QWidget):
+    """Let DWM composite the client area so alpha 0 shows the desktop."""
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+
+        hwnd = int(widget.winId())
+        if not hwnd:
+            return
+
+        class _Margins(ctypes.Structure):
+            _fields_ = [
+                ("cxLeftWidth", ctypes.c_int),
+                ("cxRightWidth", ctypes.c_int),
+                ("cyTopHeight", ctypes.c_int),
+                ("cyBottomHeight", ctypes.c_int),
+            ]
+
+        margins = _Margins(-1, -1, -1, -1)
+        ctypes.windll.dwmapi.DwmExtendFrameIntoClientArea(hwnd, ctypes.byref(margins))
+    except Exception:
+        pass
+
+
+def list_overlay_screens() -> list[dict]:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        return []
+    primary = app.primaryScreen()
+    screens = []
+    for index, screen in enumerate(app.screens()):
+        geo = screen.geometry()
+        name = screen.name() or f"Display {index + 1}"
+        tag = " (primary)" if screen is primary else ""
+        screens.append(
+            {
+                "index": index,
+                "name": name,
+                "width": int(geo.width()),
+                "height": int(geo.height()),
+                "x": int(geo.x()),
+                "y": int(geo.y()),
+                "label": f"{index + 1}: {name} — {geo.width()}×{geo.height()}{tag}",
+            }
+        )
+    return screens
+
+
+def resolve_overlay_screen(canvas: dict | None) -> dict | None:
+    screens = list_overlay_screens()
+    if not screens:
+        return None
+    canvas = canvas or {}
+    name = str(canvas.get("monitor_name") or "").strip()
+    if name:
+        for screen in screens:
+            if screen["name"] == name:
+                return screen
+    try:
+        index = int(canvas.get("monitor_index") or 0)
+    except (TypeError, ValueError):
+        index = 0
+    if 0 <= index < len(screens):
+        return screens[index]
+    return screens[0]
+
+
+def apply_onscreen_geometry(scene: OverlayScene, monitor_index=None, emit: bool = True, page_id: str | None = None) -> bool:
+    """Size the canvas to the chosen monitor when on-screen mode is active."""
+    canvas = scene.canvas_for(page_id)
+    if not is_onscreen_mode(canvas):
+        return False
+    if monitor_index is not None:
+        canvas["monitor_index"] = int(monitor_index)
+        canvas["monitor_name"] = ""
+    info = resolve_overlay_screen(canvas)
+    if not info:
+        return False
+    changed = False
+    for key in ("width", "height", "monitor_index", "monitor_name"):
+        value = info["index"] if key == "monitor_index" else info["name"] if key == "monitor_name" else info[key]
+        if canvas.get(key) != value:
+            canvas[key] = value
+            changed = True
+    if changed:
+        scene._dirty = True
+        if emit:
+            scene.changed.emit()
+    return changed
+
+
+def _window_on_a_screen(widget: QtWidgets.QWidget) -> bool:
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        return True
+    geo = widget.frameGeometry()
+    for screen in app.screens():
+        if screen.availableGeometry().intersects(geo) or screen.geometry().intersects(geo):
+            return True
+    return False
+
+
+def _center_on_screen(widget: QtWidgets.QWidget):
+    app = QtWidgets.QApplication.instance()
+    screen = app.primaryScreen() if app is not None else None
+    if screen is None:
+        return
+    frame = widget.frameGeometry()
+    frame.moveCenter(screen.availableGeometry().center())
+    widget.move(frame.topLeft())
+
+
+class OverlayView(QtWidgets.QWidget):
+    """Paints an overlay scene at 1:1 canvas size (designer may zoom)."""
+
+    zoom_changed = QtCore.Signal(float)
+
+    def __init__(self, scene: OverlayScene, interactive: bool = False, touch_output: bool = False, parent=None, page_id: str | None = None):
+        super().__init__(parent)
+        self.scene = scene
+        self._page_id = page_id
+        self.interactive = interactive
+        self.touch_output = bool(touch_output)
+        self.bus = OverlayValueBus()
+        self._zoom = 1.0
+        self._scene_origin = QtCore.QPoint(0, 0)
+        self._rubber = QtCore.QRectF()
+        self._grid_pm: QtGui.QPixmap | None = None
+        self._touch = OverlayTouchHandler(self) if self.touch_output else None
+        self.setMouseTracking(interactive or self.touch_output)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus if interactive else QtCore.Qt.NoFocus)
+        if live_window_is_layered(self.page_canvas, designer=interactive):
+            self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
+            self.setAttribute(QtCore.Qt.WA_NoSystemBackground, True)
+            _transparent_palette(self)
+        if self.touch_output:
+            self.setAttribute(QtCore.Qt.WA_AcceptTouchEvents, True)
+            self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents, False)
+        self._sync_paint_mode()
+        self._apply_size()
+        self._scene_connected = False
+        self.scene.changed.connect(self._on_scene_changed)
+        self._scene_connected = True
+        self._bus_connected = False
+
+    @property
+    def page_id(self) -> str | None:
+        return self._page_id
+
+    @property
+    def page_canvas(self) -> dict:
+        return self.scene.canvas_for(self._page_id)
+
+    @property
+    def page_widgets(self) -> list:
+        return self.scene.widgets_for(self._page_id)
+
+    def detach_from_scene(self):
+        if self._scene_connected:
+            try:
+                self.scene.changed.disconnect(self._on_scene_changed)
+            except Exception:
+                pass
+            self._scene_connected = False
+        self.release_touch()
+        self.detach_bus()
+
+    @property
+    def zoom(self) -> float:
+        return self._zoom
+
+    def set_zoom(self, zoom: float):
+        if not self.interactive:
+            return
+        zoom = max(0.25, min(4.0, float(zoom)))
+        zoom = round(zoom * 100.0) / 100.0
+        if abs(zoom - self._zoom) < 0.001:
+            return
+        self._zoom = zoom
+        self._grid_pm = None
+        self._apply_size()
+        self.update()
+        self.zoom_changed.emit(zoom)
+
+    def canvas_size(self) -> tuple[int, int]:
+        w = max(64, int(self.page_canvas.get("width") or 1280))
+        h = max(64, int(self.page_canvas.get("height") or 720))
+        return w, h
+
+    def _content_rect(self) -> QtCore.QRect:
+        """Scene rect that includes the canvas and, in the designer, overflow widgets."""
+        cw, ch = self.canvas_size()
+        canvas = QtCore.QRect(0, 0, cw, ch)
+        if not self.interactive:
+            return canvas
+        bounds = QtCore.QRect(canvas)
+        for item in self.page_widgets:
+            try:
+                x = int(item.get("x") or 0)
+                y = int(item.get("y") or 0)
+                w = max(1, int(item.get("w") or 1))
+                h = max(1, int(item.get("h") or 1))
+            except (TypeError, ValueError):
+                continue
+            bounds = bounds.united(QtCore.QRect(x, y, w, h))
+        if bounds == canvas:
+            return canvas
+        pad = DESIGNER_OVERFLOW_PAD
+        return bounds.adjusted(-pad, -pad, pad, pad).united(canvas)
+
+    def map_to_scene(self, pos: QtCore.QPointF) -> QtCore.QPointF:
+        z = self._zoom or 1.0
+        origin = self._scene_origin
+        return QtCore.QPointF(pos.x() / z + origin.x(), pos.y() / z + origin.y())
+
+    def _scene_clip(self, widget_rect: QtCore.QRect) -> QtCore.QRect:
+        z = self._zoom or 1.0
+        ox, oy = self._scene_origin.x(), self._scene_origin.y()
+        if abs(z - 1.0) < 0.001:
+            return widget_rect.translated(ox, oy)
+        inv = 1.0 / z
+        return QtCore.QRect(
+            math.floor(widget_rect.x() * inv) + ox - 2,
+            math.floor(widget_rect.y() * inv) + oy - 2,
+            math.ceil(widget_rect.width() * inv) + 4,
+            math.ceil(widget_rect.height() * inv) + 4,
+        )
+
+    def _widget_rect(self, scene_rect: QtCore.QRect) -> QtCore.QRect:
+        z = self._zoom or 1.0
+        ox, oy = self._scene_origin.x(), self._scene_origin.y()
+        if abs(z - 1.0) < 0.001:
+            return scene_rect.translated(-ox, -oy)
+        return QtCore.QRect(
+            math.floor((scene_rect.x() - ox) * z),
+            math.floor((scene_rect.y() - oy) * z),
+            max(1, math.ceil(scene_rect.width() * z) + 1),
+            max(1, math.ceil(scene_rect.height() * z) + 1),
+        )
+
+    def attach_bus(self):
+        if not Shiboken.isValid(self):
+            return
+        self.bus.set_widgets(self.page_widgets)
+        if not self._bus_connected:
+            self.bus.attach(self.page_widgets)
+            self.bus.values_changed.connect(self._on_values_changed)
+            self._bus_connected = True
+
+    def detach_bus(self):
+        if not self._bus_connected:
+            return
+        try:
+            self.bus.values_changed.disconnect(self._on_values_changed)
+        except Exception:
+            pass
+        self._bus_connected = False
+        self.bus.detach()
+
+    def _on_values_changed(self, widget_ids=None):
+        if not Shiboken.isValid(self):
+            return
+        if not widget_ids:
+            self.update()
+            return
+        united = QtCore.QRect()
+        for widget_id in widget_ids:
+            item = self.scene.widget_by_id(widget_id, self._page_id)
+            if not item:
+                continue
+            rect = self._widget_rect(widget_dirty_rect(item))
+            united = rect if united.isNull() else united.united(rect)
+        if united.isNull():
+            self.update()
+        else:
+            self.update(united)
+
+    def _on_scene_changed(self):
+        if not Shiboken.isValid(self):
+            return
+        self.bus.set_widgets(self.page_widgets)
+        self._grid_pm = None
+        self._sync_paint_mode()
+        self._apply_size()
+        self.update()
+
+    def _sync_paint_mode(self):
+        if not Shiboken.isValid(self):
+            return
+        layered = live_window_is_layered(self.page_canvas, designer=self.interactive)
+        opaque = not layered
+        if self.testAttribute(QtCore.Qt.WA_OpaquePaintEvent) != opaque:
+            self.setAttribute(QtCore.Qt.WA_OpaquePaintEvent, opaque)
+        if not self.testAttribute(QtCore.Qt.WA_NoSystemBackground):
+            self.setAttribute(QtCore.Qt.WA_NoSystemBackground, True)
+        if self.testAttribute(QtCore.Qt.WA_TranslucentBackground) != layered:
+            self.setAttribute(QtCore.Qt.WA_TranslucentBackground, layered)
+
+    def _apply_size(self):
+        content = self._content_rect()
+        old_origin = QtCore.QPoint(self._scene_origin)
+        origin = content.topLeft()
+        z = self._zoom if self.interactive else 1.0
+        zw = max(64, int(round(content.width() * z)))
+        zh = max(64, int(round(content.height() * z)))
+        if self._scene_origin != origin or self.width() != zw or self.height() != zh:
+            self._grid_pm = None
+        self._scene_origin = origin
+        if self.interactive and origin != old_origin:
+            self._nudge_scroll((old_origin.x() - origin.x()) * z, (old_origin.y() - origin.y()) * z)
+        self.setFixedSize(zw, zh)
+
+    def _nudge_scroll(self, dx: float, dy: float):
+        parent = self.parent()
+        while parent is not None and not isinstance(parent, QtWidgets.QScrollArea):
+            parent = parent.parent()
+        if not isinstance(parent, QtWidgets.QScrollArea):
+            return
+        if abs(dx) >= 1:
+            bar = parent.horizontalScrollBar()
+            bar.setValue(bar.value() + int(round(dx)))
+        if abs(dy) >= 1:
+            bar = parent.verticalScrollBar()
+            bar.setValue(bar.value() + int(round(dy)))
+
+    def paintEvent(self, event):
+        painter = QtGui.QPainter(self)
+        z = self._zoom if self.interactive else 1.0
+        cw, ch = self.canvas_size()
+        canvas_rect = QtCore.QRect(0, 0, cw, ch)
+        clip = event.rect()
+        scene_clip = self._scene_clip(clip)
+        if self.interactive:
+            scene_clip = scene_clip.intersected(self._content_rect())
+        else:
+            scene_clip = scene_clip.intersected(canvas_rect)
+        if abs(z - 1.0) > 0.001:
+            painter.scale(z, z)
+        origin = self._scene_origin
+        if origin.x() or origin.y():
+            painter.translate(-origin.x(), -origin.y())
+        painter.setClipRect(scene_clip)
+        # Live updates skip antialiasing so the UI thread stays free for Input Viewer.
+        painter.setRenderHint(QtGui.QPainter.Antialiasing, False)
+        layered = live_window_is_layered(self.page_canvas, designer=self.interactive)
+        if layered:
+            painter.setCompositionMode(QtGui.QPainter.CompositionMode_Source)
+            if is_onscreen_mode(self.page_canvas):
+                painter.fillRect(scene_clip, QtCore.Qt.transparent)
+            else:
+                painter.fillRect(scene_clip, chroma_fill_color(self.page_canvas))
+            if is_interactive_overlay(self.page_canvas) and not self.interactive:
+                for item in self.scene.sorted_widgets(self._page_id):
+                    if not widget_accepts_touch(item):
+                        continue
+                    hit = widget_rect(item)
+                    if hit.intersects(QtCore.QRectF(scene_clip)):
+                        painter.fillRect(hit, QtGui.QColor(0, 0, 0, 1))
+            painter.setCompositionMode(QtGui.QPainter.CompositionMode_SourceOver)
+            if not is_onscreen_mode(self.page_canvas):
+                paint_background(painter, self.page_canvas, canvas_rect, preview=False, fallback_chroma=False)
+        else:
+            if self.interactive:
+                painter.fillRect(scene_clip, DESIGNER_OVERFLOW_FILL)
+            paint_background(painter, self.page_canvas, canvas_rect, preview=self.interactive)
+            if self.interactive:
+                painter.setPen(QtGui.QPen(DESIGNER_CANVAS_BORDER, 1))
+                painter.setBrush(QtCore.Qt.NoBrush)
+                painter.drawRect(canvas_rect.adjusted(0, 0, -1, -1))
+        if self.interactive and self.page_canvas.get("snap_to_grid"):
+            self._paint_grid(painter)
+        for item in self.scene.sorted_widgets(self._page_id):
+            dirty = widget_dirty_rect(item)
+            if not dirty.intersects(scene_clip):
+                continue
+            value = self.bus.value_for(item)
+            paint_widget(painter, item, value)
+        if self.interactive:
+            self._paint_guides(painter)
+            self._paint_selection(painter)
+            if not self._rubber.isNull():
+                painter.setPen(QtGui.QPen(QtGui.QColor("#7ec8ff"), 1, QtCore.Qt.DashLine))
+                painter.setBrush(QtGui.QColor(126, 200, 255, 40))
+                painter.drawRect(self._rubber.normalized())
+        painter.end()
+
+    def _paint_grid(self, painter: QtGui.QPainter):
+        cw, ch = self.canvas_size()
+        size = QtCore.QSize(cw, ch)
+        if self._grid_pm is None or self._grid_pm.size() != size:
+            grid = max(4, int(self.page_canvas.get("grid_size") or 8))
+            pm = QtGui.QPixmap(size)
+            pm.fill(QtCore.Qt.transparent)
+            gp = QtGui.QPainter(pm)
+            gp.setPen(QtGui.QPen(QtGui.QColor(0, 0, 0, 28), 1))
+            for x in range(0, cw, grid):
+                gp.drawLine(x, 0, x, ch)
+            for y in range(0, ch, grid):
+                gp.drawLine(0, y, cw, y)
+            gp.end()
+            self._grid_pm = pm
+        painter.drawPixmap(0, 0, self._grid_pm)
+
+    def _paint_guides(self, painter: QtGui.QPainter):
+        cw, ch = self.canvas_size()
+        handle = 8.0 / max(self._zoom, 0.25)
+        for guide in self.page_canvas.get("guides") or []:
+            color = qcolor(guide.get("color"), DEFAULT_GUIDE_COLOR)
+            painter.setPen(QtGui.QPen(color, 1.2, QtCore.Qt.DashLine))
+            painter.setBrush(color)
+            pos = max(0.0, min(1.0, float(guide.get("position") or 0)))
+            if guide.get("axis") == "h":
+                y = pos * ch
+                painter.drawLine(QtCore.QPointF(0, y), QtCore.QPointF(cw, y))
+                painter.setPen(QtCore.Qt.NoPen)
+                painter.drawPolygon(
+                    QtGui.QPolygonF(
+                        [
+                            QtCore.QPointF(0, y - handle),
+                            QtCore.QPointF(handle * 1.6, y),
+                            QtCore.QPointF(0, y + handle),
+                        ]
+                    )
+                )
+            else:
+                x = pos * cw
+                painter.drawLine(QtCore.QPointF(x, 0), QtCore.QPointF(x, ch))
+                painter.setPen(QtCore.Qt.NoPen)
+                painter.drawPolygon(
+                    QtGui.QPolygonF(
+                        [
+                            QtCore.QPointF(x - handle, 0),
+                            QtCore.QPointF(x + handle, 0),
+                            QtCore.QPointF(x, handle * 1.6),
+                        ]
+                    )
+                )
+
+    def guide_at(self, pos: QtCore.QPointF) -> dict | None:
+        cw, ch = self.canvas_size()
+        if cw <= 0 or ch <= 0:
+            return None
+        tol = 6.0 / max(self._zoom, 0.25)
+        handle = 12.0 / max(self._zoom, 0.25)
+        best = None
+        best_dist = tol
+        for guide in self.page_canvas.get("guides") or []:
+            pos_t = max(0.0, min(1.0, float(guide.get("position") or 0)))
+            if guide.get("axis") == "h":
+                gy = pos_t * ch
+                dist = abs(pos.y() - gy)
+                on_handle = pos.x() <= handle * 2
+            else:
+                gx = pos_t * cw
+                dist = abs(pos.x() - gx)
+                on_handle = pos.y() <= handle * 2
+            limit = tol * 1.8 if on_handle else tol
+            if dist <= limit and dist <= best_dist:
+                best = guide
+                best_dist = dist
+        return best
+
+    def _selected_bounds(self) -> QtCore.QRectF | None:
+        bounds = QtCore.QRectF()
+        found = False
+        for widget_id in self.scene.selected_ids:
+            item = self.scene.widget_by_id(widget_id, self._page_id)
+            if not item:
+                continue
+            rect = QtCore.QRectF(
+                float(item.get("x") or 0),
+                float(item.get("y") or 0),
+                max(1.0, float(item.get("w") or 1)),
+                max(1.0, float(item.get("h") or 1)),
+            )
+            bounds = rect if not found else bounds.united(rect)
+            found = True
+        return bounds if found else None
+
+    def _paint_selection(self, painter: QtGui.QPainter):
+        painter.save()
+        multi = len(self.scene.selected_ids) > 1
+        for widget_id in self.scene.selected_ids:
+            item = self.scene.widget_by_id(widget_id, self._page_id)
+            if not item:
+                continue
+            rect = QtCore.QRectF(item["x"], item["y"], item["w"], item["h"])
+            painter.setPen(QtGui.QPen(QtGui.QColor("#7ec8ff"), 1.5))
+            painter.setBrush(QtCore.Qt.NoBrush)
+            painter.drawRect(rect.adjusted(-1, -1, 1, 1))
+            if not multi and widget_id == (self.scene.selected_ids[-1] if self.scene.selected_ids else None):
+                painter.setBrush(QtGui.QColor("#7ec8ff"))
+                hs = 4.0 / max(self._zoom, 0.25)
+                for hx, hy in self.handle_points(item):
+                    painter.drawRect(QtCore.QRectF(hx - hs, hy - hs, hs * 2, hs * 2))
+        if multi:
+            bounds = self._selected_bounds()
+            if bounds is not None:
+                painter.setPen(QtGui.QPen(QtGui.QColor("#7ec8ff"), 1.5, QtCore.Qt.DashLine))
+                painter.setBrush(QtCore.Qt.NoBrush)
+                painter.drawRect(bounds.adjusted(-2, -2, 2, 2))
+                painter.setPen(QtGui.QPen(QtGui.QColor("#7ec8ff"), 1))
+                painter.setBrush(QtGui.QColor("#7ec8ff"))
+                hs = 4.0 / max(self._zoom, 0.25)
+                dummy = {"x": bounds.x(), "y": bounds.y(), "w": bounds.width(), "h": bounds.height()}
+                for hx, hy in self.handle_points(dummy):
+                    painter.drawRect(QtCore.QRectF(hx - hs, hy - hs, hs * 2, hs * 2))
+        painter.restore()
+
+    def handle_points(self, item: dict):
+        x, y, w, h = item["x"], item["y"], item["w"], item["h"]
+        return [
+            (x, y),
+            (x + w / 2, y),
+            (x + w, y),
+            (x + w, y + h / 2),
+            (x + w, y + h),
+            (x + w / 2, y + h),
+            (x, y + h),
+            (x, y + h / 2),
+        ]
+
+    def handle_at(self, pos: QtCore.QPointF) -> tuple[str | None, int]:
+        if not self.scene.selected_ids:
+            return None, -1
+        if len(self.scene.selected_ids) > 1:
+            bounds = self._selected_bounds()
+            if bounds is None:
+                return None, -1
+            item = {"x": bounds.x(), "y": bounds.y(), "w": bounds.width(), "h": bounds.height()}
+            target_id = self.scene.selected_ids[-1]
+        else:
+            item = self.scene.widget_by_id(self.scene.selected_ids[-1], self._page_id)
+            if not item:
+                return None, -1
+            target_id = item["id"]
+        tol = 6.0 / max(self._zoom, 0.25)
+        for index, (hx, hy) in enumerate(self.handle_points(item)):
+            if abs(pos.x() - hx) <= tol and abs(pos.y() - hy) <= tol:
+                return target_id, index
+        return None, -1
+
+    def release_touch(self):
+        if self._touch is not None:
+            self._touch.release_all()
+
+    def event(self, event: QtCore.QEvent) -> bool:
+        if self._touch is not None and event.type() in (
+            QtCore.QEvent.Type.TouchBegin,
+            QtCore.QEvent.Type.TouchUpdate,
+            QtCore.QEvent.Type.TouchEnd,
+            QtCore.QEvent.Type.TouchCancel,
+        ):
+            handled = self._handle_touch(event)
+            if handled or event.type() != QtCore.QEvent.Type.TouchBegin:
+                event.accept()
+                return True
+            return False
+        return super().event(event)
+
+    def nativeEvent(self, eventType, message):
+        result = _handle_nchittest(self, eventType, message)
+        if result is not None:
+            return result
+        return super().nativeEvent(eventType, message)
+
+    def _handle_touch(self, event) -> bool:
+        if self._touch is None or not self._touch.enabled():
+            if event.type() == QtCore.QEvent.Type.TouchCancel:
+                self.release_touch()
+            return False
+        handled = False
+        for point in event.points():
+            pid = ("touch", int(point.id()))
+            state = point.state()
+            scene = self.map_to_scene(point.position())
+            if state == QtGui.QEventPoint.State.Pressed:
+                handled = self._touch.press(pid, scene) or handled
+            elif state == QtGui.QEventPoint.State.Updated:
+                handled = self._touch.move(pid, scene) or handled
+            elif state == QtGui.QEventPoint.State.Released:
+                handled = self._touch.release(pid) or handled
+        if event.type() == QtCore.QEvent.Type.TouchCancel:
+            self.release_touch()
+            return True
+        return handled
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent):
+        if self.interactive or self._touch is None or event.button() != QtCore.Qt.LeftButton:
+            super().mousePressEvent(event)
+            return
+        if self._touch.press("mouse", self.map_to_scene(event.position())):
+            event.accept()
+            return
+        event.ignore()
+
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent):
+        if self.interactive or self._touch is None:
+            super().mouseMoveEvent(event)
+            return
+        self._touch.move("mouse", self.map_to_scene(event.position()))
+        event.accept()
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent):
+        if self.interactive or self._touch is None or event.button() != QtCore.Qt.LeftButton:
+            super().mouseReleaseEvent(event)
+            return
+        self._touch.release("mouse")
+        event.accept()
+
+
+class OverlayWindow(QtWidgets.QWidget):
+    """Bordered-or-frameless capture window titled GEX Overlay — {page}."""
+
+    def __init__(self, scene: OverlayScene, parent=None, page_id: str | None = None):
+        super().__init__(parent)
+        self.scene = scene
+        self.page_id = page_id or scene.active_page_id
+        self.setObjectName("GexOverlayWindow")
+        page = scene.page_by_id(self.page_id)
+        self.setWindowTitle(overlay_window_title(page))
+        if live_window_is_layered(self.page_canvas):
+            self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
+            self.setAttribute(QtCore.Qt.WA_NoSystemBackground, True)
+            _transparent_palette(self)
+        self.view = OverlayView(scene, interactive=False, touch_output=True, parent=self, page_id=self.page_id)
+        self.drag_bar = QtWidgets.QWidget(self)
+        self.drag_bar.setFixedHeight(22)
+        self.drag_bar.setCursor(QtCore.Qt.SizeAllCursor)
+        self._drag_label = QtWidgets.QLabel("GEX Overlay  —  hide this bar before capturing")
+        self._drag_label.setAlignment(QtCore.Qt.AlignCenter)
+        bar_layout = QtWidgets.QHBoxLayout(self.drag_bar)
+        bar_layout.setContentsMargins(6, 0, 6, 0)
+        bar_layout.addWidget(self._drag_label)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.drag_bar)
+        layout.addWidget(self.view)
+        self._drag_origin = None
+        self._applying_flags = False
+        self.setMouseTracking(True)
+        self.setAttribute(QtCore.Qt.WA_AcceptTouchEvents, True)
+        self.drag_bar.installEventFilter(self)
+        self._chrome_sig = None
+        self._scene_connected = False
+        self.scene.changed.connect(self._on_scene_changed)
+        self._scene_connected = True
+        self._apply_window_flags()
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._context_menu)
+
+    @property
+    def page_canvas(self) -> dict:
+        return self.scene.canvas_for(self.page_id)
+
+    def nativeEvent(self, eventType, message):
+        result = _handle_nchittest(self, eventType, message)
+        if result is not None:
+            return result
+        return super().nativeEvent(eventType, message)
+
+    def event(self, event: QtCore.QEvent) -> bool:
+        if event.type() in (
+            QtCore.QEvent.Type.TouchBegin,
+            QtCore.QEvent.Type.TouchUpdate,
+            QtCore.QEvent.Type.TouchEnd,
+            QtCore.QEvent.Type.TouchCancel,
+        ) and is_interactive_overlay(self.page_canvas):
+            if self._forward_window_touch(event):
+                event.accept()
+                return True
+        return super().event(event)
+
+    def _forward_window_touch(self, event) -> bool:
+        touch = getattr(self.view, "_touch", None)
+        if touch is None:
+            return False
+        handled = False
+        for point in event.points():
+            win_pos = point.position().toPoint()
+            if self.drag_bar.isVisible() and self.drag_bar.geometry().contains(win_pos):
+                continue
+            local = self.view.mapFrom(self, win_pos)
+            scene = self.view.map_to_scene(QtCore.QPointF(local))
+            pid = ("touch", int(point.id()))
+            state = point.state()
+            if state == QtGui.QEventPoint.State.Pressed:
+                handled = touch.press(pid, scene) or handled
+            elif state == QtGui.QEventPoint.State.Updated:
+                handled = touch.move(pid, scene) or handled
+            elif state == QtGui.QEventPoint.State.Released:
+                handled = touch.release(pid) or handled
+        if event.type() == QtCore.QEvent.Type.TouchCancel:
+            self.view.release_touch()
+            return True
+        return handled
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if Shiboken.isValid(self.view):
+            self.view.attach_bus()
+        if not self._applying_flags:
+            click_through = is_onscreen_mode(self.page_canvas) and not is_interactive_overlay(self.page_canvas)
+            self._apply_click_through(click_through)
+        if live_window_is_layered(self.page_canvas):
+            _extend_frame_into_client(self)
+
+    def detach_from_scene(self):
+        if self._scene_connected:
+            try:
+                self.scene.changed.disconnect(self._on_scene_changed)
+            except Exception:
+                pass
+            self._scene_connected = False
+        view = getattr(self, "view", None)
+        if view is not None and Shiboken.isValid(view):
+            view.detach_from_scene()
+
+    def hideEvent(self, event):
+        view = getattr(self, "view", None)
+        if view is not None and Shiboken.isValid(view):
+            view.release_touch()
+            view.detach_bus()
+        super().hideEvent(event)
+
+    def closeEvent(self, event):
+        self.detach_from_scene()
+        super().closeEvent(event)
+
+    def paintEvent(self, event):
+        if live_window_is_layered(self.page_canvas):
+            painter = QtGui.QPainter(self)
+            painter.setCompositionMode(QtGui.QPainter.CompositionMode_Source)
+            painter.fillRect(event.rect(), QtGui.QColor(0, 0, 0, 0))
+            painter.end()
+            return
+        super().paintEvent(event)
+
+    def _chrome_signature(self):
+        canvas = self.page_canvas
+        page = self.scene.page_by_id(self.page_id) or {}
+        return (
+            self.page_id,
+            page.get("name"),
+            page.get("window_x"),
+            page.get("window_y"),
+            normalize_background_mode(canvas.get("background_mode")),
+            canvas.get("width"),
+            canvas.get("height"),
+            canvas.get("monitor_index"),
+            canvas.get("monitor_name"),
+            canvas.get("frameless"),
+            canvas.get("always_on_top"),
+            canvas.get("show_drag_bar"),
+            canvas.get("chroma_color"),
+            canvas.get("interactive"),
+        )
+
+    def _sync_page_title(self):
+        page = self.scene.page_by_id(self.page_id)
+        title = overlay_window_title(page)
+        self.setWindowTitle(title)
+        if getattr(self, "_drag_label", None) is not None:
+            name = (page or {}).get("name") or "Overlay"
+            self._drag_label.setText(f"{OVERLAY_WINDOW_TITLE} — {name}  —  hide this bar before capturing")
+
+    def _restore_or_center(self):
+        if is_onscreen_mode(self.page_canvas):
+            return
+        page = self.scene.page_by_id(self.page_id)
+        if page is None:
+            _center_on_screen(self)
+            return
+        wx, wy = page.get("window_x"), page.get("window_y")
+        if wx is None or wy is None:
+            _center_on_screen(self)
+            return
+        self.move(int(wx), int(wy))
+        if not _window_on_a_screen(self):
+            page["window_x"] = None
+            page["window_y"] = None
+            self.scene._dirty = True
+            _center_on_screen(self)
+
+    def _record_window_position(self):
+        if self._applying_flags or is_onscreen_mode(self.page_canvas):
+            return
+        self.scene.record_page_position(self.x(), self.y(), page_id=self.page_id, emit=False)
+        self._chrome_sig = self._chrome_signature()
+
+    def _on_scene_changed(self):
+        if not Shiboken.isValid(self):
+            return
+        sig = self._chrome_signature()
+        if sig == self._chrome_sig:
+            return
+        self._apply_window_flags()
+
+    def _apply_window_flags(self):
+        if self._applying_flags or not Shiboken.isValid(self):
+            return
+        self._applying_flags = True
+        try:
+            self._chrome_sig = self._chrome_signature()
+            self._sync_page_title()
+            onscreen = is_onscreen_mode(self.page_canvas)
+            interactive = is_interactive_overlay(self.page_canvas)
+            visible = self.isVisible()
+            if onscreen:
+                flags = (
+                    QtCore.Qt.Window
+                    | QtCore.Qt.FramelessWindowHint
+                    | QtCore.Qt.WindowStaysOnTopHint
+                    | QtCore.Qt.Tool
+                )
+                if not interactive:
+                    flags |= QtCore.Qt.WindowDoesNotAcceptFocus | QtCore.Qt.WindowTransparentForInput
+                self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
+                self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents, not interactive)
+                self.setAttribute(QtCore.Qt.WA_ShowWithoutActivating, not interactive)
+                self.setAttribute(QtCore.Qt.WA_AcceptTouchEvents, interactive)
+                flags_changed = int(self.windowFlags()) != int(flags)
+                if flags_changed:
+                    self.setWindowFlags(flags)
+                    self._sync_page_title()
+                self.drag_bar.setVisible(False)
+                apply_onscreen_geometry(self.scene, emit=False, page_id=self.page_id)
+                info = resolve_overlay_screen(self.page_canvas)
+                if Shiboken.isValid(self.view):
+                    self.view._sync_paint_mode()
+                    self.view._apply_size()
+                if info:
+                    self.setGeometry(info["x"], info["y"], info["width"], info["height"])
+                else:
+                    self.adjustSize()
+            else:
+                layered = live_window_is_layered(self.page_canvas)
+                flags = QtCore.Qt.Window | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowCloseButtonHint
+                if layered or self.page_canvas.get("frameless"):
+                    flags = QtCore.Qt.Window | QtCore.Qt.FramelessWindowHint
+                if self.page_canvas.get("always_on_top"):
+                    flags |= QtCore.Qt.WindowStaysOnTopHint
+                self.setAttribute(QtCore.Qt.WA_TranslucentBackground, layered)
+                self.setAttribute(QtCore.Qt.WA_NoSystemBackground, layered)
+                self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents, False)
+                self.setAttribute(QtCore.Qt.WA_ShowWithoutActivating, False)
+                self.setAttribute(QtCore.Qt.WA_AcceptTouchEvents, interactive)
+                if layered:
+                    _transparent_palette(self)
+                    if Shiboken.isValid(self.view):
+                        _transparent_palette(self.view)
+                flags_changed = int(self.windowFlags()) != int(flags)
+                if flags_changed:
+                    self.setWindowFlags(flags)
+                    self._sync_page_title()
+                show_bar = bool(self.page_canvas.get("show_drag_bar", True)) or layered
+                self.drag_bar.setVisible(show_bar)
+                chroma = chroma_fill_color(self.page_canvas)
+                bar = chroma if chroma.alpha() > 80 else QtGui.QColor("#8a93a3")
+                self.drag_bar.setStyleSheet(f"background:{bar.darker(130).name()}; color:#111;")
+                if Shiboken.isValid(self.view):
+                    self.view._sync_paint_mode()
+                    self.view._apply_size()
+                self.adjustSize()
+                self._restore_or_center()
+            if visible and flags_changed:
+                self.show()
+            self._apply_click_through(onscreen and not interactive)
+            if live_window_is_layered(self.page_canvas) and (visible or self.isVisible()):
+                _extend_frame_into_client(self)
+        finally:
+            self._applying_flags = False
+
+    def _apply_click_through(self, enabled: bool):
+        if sys.platform != "win32":
+            return
+        try:
+            import ctypes
+
+            hwnd = int(self.winId())
+            if not hwnd:
+                return
+            user32 = ctypes.windll.user32
+            gwl_exstyle = -20
+            ws_ex_transparent = 0x00000020
+            ws_ex_noactivate = 0x08000000
+            ws_ex_toolwindow = 0x00000080
+            if ctypes.sizeof(ctypes.c_void_p) == 8:
+                user32.GetWindowLongPtrW.restype = ctypes.c_longlong
+                user32.SetWindowLongPtrW.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_longlong]
+                style = user32.GetWindowLongPtrW(hwnd, gwl_exstyle)
+                extras = ws_ex_transparent | ws_ex_noactivate | ws_ex_toolwindow
+                style = (style | extras) if enabled else (style & ~extras)
+                user32.SetWindowLongPtrW(hwnd, gwl_exstyle, style)
+            else:
+                style = user32.GetWindowLongW(hwnd, gwl_exstyle)
+                extras = ws_ex_transparent | ws_ex_noactivate | ws_ex_toolwindow
+                style = (style | extras) if enabled else (style & ~extras)
+                user32.SetWindowLongW(hwnd, gwl_exstyle, style)
+            user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0004 | 0x0020)
+        except Exception as err:
+            syslog.warning(f"OBS OVERLAY: click-through style failed: {err}")
+
+    def _view_scene_pos(self, event: QtGui.QMouseEvent) -> QtCore.QPointF | None:
+        local = self.view.mapFrom(self, event.position().toPoint())
+        if not self.view.rect().contains(local):
+            return None
+        return self.view.map_to_scene(QtCore.QPointF(local))
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent):
+        touch = getattr(self.view, "_touch", None)
+        if event.button() == QtCore.Qt.LeftButton and touch is not None and is_interactive_overlay(self.page_canvas):
+            scene = self._view_scene_pos(event)
+            if scene is not None and touch.press("mouse", scene):
+                event.accept()
+                return
+            event.ignore()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent):
+        touch = getattr(self.view, "_touch", None)
+        if touch is not None and is_interactive_overlay(self.page_canvas) and event.buttons() & QtCore.Qt.LeftButton:
+            scene = self._view_scene_pos(event)
+            if scene is not None:
+                touch.move("mouse", scene)
+                event.accept()
+                return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent):
+        touch = getattr(self.view, "_touch", None)
+        if event.button() == QtCore.Qt.LeftButton and touch is not None:
+            touch.release("mouse")
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+    def eventFilter(self, watched, event):
+        if watched is self.drag_bar:
+            if event.type() == QtCore.QEvent.MouseButtonPress and event.button() == QtCore.Qt.LeftButton:
+                self._drag_origin = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+                return True
+            if event.type() == QtCore.QEvent.MouseMove and self._drag_origin is not None and event.buttons() & QtCore.Qt.LeftButton:
+                self.move(event.globalPosition().toPoint() - self._drag_origin)
+                return True
+            if event.type() == QtCore.QEvent.MouseButtonRelease:
+                self._drag_origin = None
+                self._record_window_position()
+                return True
+        return super().eventFilter(watched, event)
+
+    def moveEvent(self, event):
+        super().moveEvent(event)
+        self._record_window_position()
+
+    def _context_menu(self, pos):
+        if is_onscreen_mode(self.page_canvas):
+            return
+        menu = QtWidgets.QMenu(self)
+        top = menu.addAction("Always on top")
+        top.setCheckable(True)
+        top.setChecked(bool(self.page_canvas.get("always_on_top")))
+        bar = menu.addAction("Show drag bar")
+        bar.setCheckable(True)
+        bar.setChecked(bool(self.page_canvas.get("show_drag_bar", True)))
+        frame = menu.addAction("Frameless window")
+        frame.setCheckable(True)
+        frame.setChecked(bool(self.page_canvas.get("frameless")))
+        menu.addSeparator()
+        close_action = menu.addAction("Close overlay")
+        chosen = menu.exec(self.mapToGlobal(pos))
+        if chosen is top:
+            self.page_canvas["always_on_top"] = top.isChecked()
+            self.scene._dirty = True
+            self._apply_window_flags()
+            self.show()
+        elif chosen is bar:
+            self.page_canvas["show_drag_bar"] = bar.isChecked()
+            self.scene._dirty = True
+            self._apply_window_flags()
+        elif chosen is frame:
+            self.page_canvas["frameless"] = frame.isChecked()
+            self.scene._dirty = True
+            self._apply_window_flags()
+            self.show()
+        elif chosen is close_action:
+            self.hide()

--- a/gremlin/ui/obs_overlay/palettes.py
+++ b/gremlin/ui/obs_overlay/palettes.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import uuid
+from typing import Any
+
+import gremlin.shared_state
+
+from .model import default_style
+
+COLOR_KEYS = (
+    "fill",
+    "fill_on",
+    "border",
+    "border_on",
+    "indicator",
+    "track",
+    "fill_bar",
+    "grid",
+    "crosshair",
+    "needle",
+    "font_color",
+    "axis_label_font_color",
+)
+
+BUILTIN_IDS = ("default", "touchosc", "green_clear")
+
+TOUCHOSC_COLORS = {
+    "fill": "#000000",
+    "fill_on": "#ff0000",
+    "border": "#ff0000",
+    "border_on": "#ff4d4d",
+    "indicator": "#ff0000",
+    "track": "#000000",
+    "fill_bar": "#ff0000",
+    "grid": "#4d0000",
+    "crosshair": "#ff3333",
+    "needle": "#ff0000",
+    "font_color": "#ff1a1a",
+    "axis_label_font_color": "#ff1a1a",
+}
+
+GREEN_CLEAR_COLORS = {
+    "fill": "#00000000",
+    "fill_on": "#3dff9a",
+    "border": "#3dff9a",
+    "border_on": "#7dffb8",
+    "indicator": "#3dff9a",
+    "track": "#00000000",
+    "fill_bar": "#3dff9a",
+    "grid": "#2a8f5c",
+    "crosshair": "#3dff9a",
+    "needle": "#3dff9a",
+    "font_color": "#3dff9a",
+    "axis_label_font_color": "#3dff9a",
+}
+
+
+def palette_type(widget_type: str | None) -> str:
+    if widget_type == "axis_dial":
+        return "axis_radial"
+    if widget_type == "panel":
+        return "shape"
+    return widget_type or "button"
+
+
+def extract_colors(style: dict[str, Any] | None, widget_type: str | None = None) -> dict[str, str]:
+    style = style or {}
+    fallback = default_style(palette_type(widget_type))
+    colors = {}
+    for key in COLOR_KEYS:
+        value = style.get(key)
+        if value in (None, ""):
+            value = fallback.get(key)
+        colors[key] = str(value or "#ffffff")
+    return colors
+
+
+def _builtin_palettes(widget_type: str) -> list[dict[str, Any]]:
+    kind = palette_type(widget_type)
+    return [
+        {"id": "default", "label": "Default", "colors": extract_colors(default_style(kind), kind)},
+        {"id": "touchosc", "label": "Touch OSC", "colors": dict(TOUCHOSC_COLORS)},
+        {"id": "green_clear", "label": "Transparent green", "colors": dict(GREEN_CLEAR_COLORS)},
+    ]
+
+
+def palettes_path() -> str:
+    root = gremlin.shared_state.data_path
+    if not root:
+        root = os.path.join(os.path.expanduser("~"), "Joystick Gremlin Ex")
+    return os.path.join(root, "overlay_color_palettes.json")
+
+
+def _load_store() -> dict[str, Any]:
+    path = palettes_path()
+    if not os.path.isfile(path):
+        return {"version": 1, "palettes": {}}
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:
+        return {"version": 1, "palettes": {}}
+    if not isinstance(data, dict):
+        return {"version": 1, "palettes": {}}
+    palettes = data.get("palettes")
+    if not isinstance(palettes, dict):
+        data["palettes"] = {}
+    return data
+
+
+def _save_store(data: dict[str, Any]):
+    path = palettes_path()
+    folder = os.path.dirname(path)
+    if folder and not os.path.isdir(folder):
+        os.makedirs(folder, exist_ok=True)
+    payload = {"version": 1, "palettes": data.get("palettes") or {}}
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def list_builtin_palettes(widget_type: str) -> list[dict[str, Any]]:
+    return [copy.deepcopy(item) for item in _builtin_palettes(palette_type(widget_type))]
+
+
+def list_user_palettes(widget_type: str) -> list[dict[str, Any]]:
+    kind = palette_type(widget_type)
+    extras = []
+    for raw in (_load_store().get("palettes") or {}).get(kind) or []:
+        if not isinstance(raw, dict) or not raw.get("id"):
+            continue
+        palette_id = str(raw["id"])
+        if palette_id in BUILTIN_IDS:
+            continue
+        extras.append(
+            {
+                "id": palette_id,
+                "label": str(raw.get("label") or "Saved palette"),
+                "colors": extract_colors(raw.get("colors") or {}, kind),
+            }
+        )
+    return extras
+
+
+def list_palettes(widget_type: str) -> list[dict[str, Any]]:
+    return list_builtin_palettes(widget_type) + list_user_palettes(widget_type)
+
+
+def update_palette(widget_type: str, palette_id: str, colors: dict[str, str], label: str | None = None) -> str:
+    kind = palette_type(widget_type)
+    palette_id = str(palette_id or uuid.uuid4())
+    if palette_id in BUILTIN_IDS:
+        return palette_id
+    data = _load_store()
+    palettes = data.setdefault("palettes", {})
+    entries = list(palettes.get(kind) or [])
+    payload = {"id": palette_id, "colors": extract_colors(colors, kind)}
+    if label:
+        payload["label"] = label
+    replaced = False
+    for index, raw in enumerate(entries):
+        if isinstance(raw, dict) and str(raw.get("id")) == palette_id:
+            if not payload.get("label") and raw.get("label"):
+                payload["label"] = raw.get("label")
+            entries[index] = payload
+            replaced = True
+            break
+    if not replaced:
+        entries.append(payload)
+    palettes[kind] = entries
+    _save_store(data)
+    return palette_id
+
+
+def add_palette(widget_type: str, colors: dict[str, str]) -> str:
+    return update_palette(widget_type, str(uuid.uuid4()), colors, label="Saved palette")
+
+
+def delete_palette(widget_type: str, palette_id: str) -> bool:
+    if palette_id in BUILTIN_IDS:
+        return False
+    kind = palette_type(widget_type)
+    data = _load_store()
+    palettes = data.setdefault("palettes", {})
+    before = palettes.get(kind) or []
+    after = [raw for raw in before if not (isinstance(raw, dict) and str(raw.get("id")) == palette_id)]
+    if len(after) == len(before):
+        return False
+    palettes[kind] = after
+    _save_store(data)
+    return True

--- a/gremlin/ui/obs_overlay/shapes.py
+++ b/gremlin/ui/obs_overlay/shapes.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8; -*-
+
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6 import QtCore, QtGui
+
+
+SHAPE_KINDS = (
+    "rectangle",
+    "circle",
+    "triangle",
+    "diamond",
+    "line",
+    "freeform",
+)
+
+SHAPE_KIND_LABELS = (
+    ("rectangle", "Rectangle"),
+    ("circle", "Circle"),
+    ("triangle", "Triangle"),
+    ("diamond", "Diamond"),
+    ("line", "Line"),
+    ("freeform", "Freeform"),
+)
+
+
+def normalize_shape_kind(value) -> str:
+    kind = str(value or "rectangle").casefold().replace(" ", "_")
+    if kind in ("rect", "rounded", "panel"):
+        return "rectangle"
+    if kind in ("ellipse", "oval"):
+        return "circle"
+    if kind in ("poly", "polygon", "bezier"):
+        return "freeform"
+    if kind in ("lines", "polyline"):
+        return "line"
+    return kind if kind in SHAPE_KINDS else "rectangle"
+
+
+def is_shape_widget(item: dict[str, Any] | None) -> bool:
+    return bool(item) and item.get("type") in ("shape", "panel")
+
+
+def uses_editable_points(item: dict[str, Any] | None) -> bool:
+    if not is_shape_widget(item):
+        return False
+    kind = normalize_shape_kind((item.get("style") or {}).get("shape_kind"))
+    return kind in ("triangle", "diamond", "line", "freeform")
+
+
+def _point(x: float, y: float) -> dict[str, float]:
+    return {"x": float(x), "y": float(y), "in_x": 0.0, "in_y": 0.0, "out_x": 0.0, "out_y": 0.0}
+
+
+def default_shape_points(kind: str) -> list[dict[str, float]]:
+    kind = normalize_shape_kind(kind)
+    if kind == "triangle":
+        return [_point(0.5, 0.04), _point(0.96, 0.96), _point(0.04, 0.96)]
+    if kind == "diamond":
+        return [_point(0.5, 0.04), _point(0.96, 0.5), _point(0.5, 0.96), _point(0.04, 0.5)]
+    if kind == "line":
+        return [_point(0.04, 0.5), _point(0.96, 0.5)]
+    if kind == "freeform":
+        return [_point(0.08, 0.08), _point(0.92, 0.08), _point(0.92, 0.92), _point(0.08, 0.92)]
+    return []
+
+
+def normalize_shape_points(raw, kind: str | None = None) -> list[dict[str, float]]:
+    points = []
+    for entry in raw or []:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            x = max(0.0, min(1.0, float(entry.get("x", 0))))
+            y = max(0.0, min(1.0, float(entry.get("y", 0))))
+        except (TypeError, ValueError):
+            continue
+        try:
+            in_x = float(entry.get("in_x") or 0)
+            in_y = float(entry.get("in_y") or 0)
+            out_x = float(entry.get("out_x") or 0)
+            out_y = float(entry.get("out_y") or 0)
+        except (TypeError, ValueError):
+            in_x = in_y = out_x = out_y = 0.0
+        points.append({"x": x, "y": y, "in_x": in_x, "in_y": in_y, "out_x": out_x, "out_y": out_y})
+    if len(points) < 2:
+        return default_shape_points(kind or "freeform")
+    return points
+
+
+def ensure_shape_points(item: dict[str, Any]) -> list[dict[str, float]]:
+    kind = normalize_shape_kind((item.get("style") or {}).get("shape_kind"))
+    points = normalize_shape_points(item.get("points"), kind)
+    if kind == "freeform" and points and not any(_has_handles(point) for point in points):
+        closed = shape_closed(item)
+        for index in range(len(points)):
+            _apply_tangent_handles(points, index, closed)
+    item["points"] = points
+    return points
+
+
+def shape_closed(item: dict[str, Any]) -> bool:
+    style = item.get("style") or {}
+    kind = normalize_shape_kind(style.get("shape_kind"))
+    if kind == "line":
+        return bool(style.get("shape_closed"))
+    if "shape_closed" in style:
+        return bool(style.get("shape_closed"))
+    return kind != "line"
+
+
+def _abs_point(item: dict[str, Any], point: dict[str, float]) -> QtCore.QPointF:
+    return QtCore.QPointF(
+        float(item["x"]) + float(point["x"]) * float(item["w"]),
+        float(item["y"]) + float(point["y"]) * float(item["h"]),
+    )
+
+
+def _handle_point(item: dict[str, Any], point: dict[str, float], prefix: str) -> QtCore.QPointF:
+    origin = _abs_point(item, point)
+    return QtCore.QPointF(
+        origin.x() + float(point.get(f"{prefix}_x") or 0) * float(item["w"]),
+        origin.y() + float(point.get(f"{prefix}_y") or 0) * float(item["h"]),
+    )
+
+
+def _has_handles(point: dict[str, float]) -> bool:
+    return any(abs(float(point.get(key) or 0)) > 0.0005 for key in ("in_x", "in_y", "out_x", "out_y"))
+
+
+def _apply_tangent_handles(points: list[dict[str, float]], index: int, closed: bool) -> None:
+    """Place in/out handles at 1/3 of the adjacent segments so a rectangle stays straight but is editable."""
+    count = len(points)
+    if count < 2 or index < 0 or index >= count:
+        return
+    cur = points[index]
+    if closed:
+        prev = points[(index - 1) % count]
+        nxt = points[(index + 1) % count]
+    else:
+        prev = points[index - 1] if index > 0 else None
+        nxt = points[index + 1] if index + 1 < count else None
+        if prev is None and nxt is not None:
+            prev = {"x": cur["x"] - (nxt["x"] - cur["x"]), "y": cur["y"] - (nxt["y"] - cur["y"])}
+        elif nxt is None and prev is not None:
+            nxt = {"x": cur["x"] - (prev["x"] - cur["x"]), "y": cur["y"] - (prev["y"] - cur["y"])}
+    if prev is None or nxt is None:
+        return
+    cur["in_x"] = (prev["x"] - cur["x"]) / 3.0
+    cur["in_y"] = (prev["y"] - cur["y"]) / 3.0
+    cur["out_x"] = (nxt["x"] - cur["x"]) / 3.0
+    cur["out_y"] = (nxt["y"] - cur["y"]) / 3.0
+
+
+def shape_path(item: dict[str, Any]) -> QtGui.QPainterPath:
+    style = item.get("style") or {}
+    kind = normalize_shape_kind(style.get("shape_kind"))
+    rect = QtCore.QRectF(item["x"], item["y"], item["w"], item["h"])
+    path = QtGui.QPainterPath()
+    if kind == "rectangle":
+        radius = float(style.get("corner_radius") or 0)
+        if radius > 0:
+            path.addRoundedRect(rect, radius, radius)
+        else:
+            path.addRect(rect)
+        return path
+    if kind == "circle":
+        side = min(rect.width(), rect.height())
+        path.addEllipse(QtCore.QRectF(rect.center().x() - side / 2, rect.center().y() - side / 2, side, side))
+        return path
+    points = ensure_shape_points(item)
+    if len(points) < 2:
+        path.addRect(rect)
+        return path
+    first = _abs_point(item, points[0])
+    path.moveTo(first)
+    count = len(points)
+    last_index = count if shape_closed(item) else count - 1
+    for i in range(last_index):
+        current = points[i]
+        nxt = points[(i + 1) % count]
+        dest = _abs_point(item, nxt)
+        if _has_handles(current) or _has_handles(nxt):
+            path.cubicTo(_handle_point(item, current, "out"), _handle_point(item, nxt, "in"), dest)
+        else:
+            path.lineTo(dest)
+    if shape_closed(item) and count >= 3:
+        path.closeSubpath()
+    return path
+
+
+def scene_to_normalized(item: dict[str, Any], pos: QtCore.QPointF) -> tuple[float, float]:
+    w = max(1.0, float(item.get("w") or 1))
+    h = max(1.0, float(item.get("h") or 1))
+    return (
+        max(0.0, min(1.0, (pos.x() - float(item["x"])) / w)),
+        max(0.0, min(1.0, (pos.y() - float(item["y"])) / h)),
+    )
+
+
+def closest_segment(item: dict[str, Any], pos: QtCore.QPointF) -> tuple[int, float]:
+    points = ensure_shape_points(item)
+    if len(points) < 2:
+        return 0, 1e9
+    best_i = 0
+    best_d = 1e9
+    count = len(points)
+    steps = count if shape_closed(item) else count - 1
+    for i in range(steps):
+        a = _abs_point(item, points[i])
+        b = _abs_point(item, points[(i + 1) % count])
+        dist = _distance_to_segment(pos, a, b)
+        if dist < best_d:
+            best_d = dist
+            best_i = i
+    return best_i, best_d
+
+
+def _distance_to_segment(pos: QtCore.QPointF, a: QtCore.QPointF, b: QtCore.QPointF) -> float:
+    ax, ay = a.x(), a.y()
+    bx, by = b.x(), b.y()
+    dx, dy = bx - ax, by - ay
+    length = dx * dx + dy * dy
+    if length <= 1e-6:
+        return QtCore.QLineF(pos, a).length()
+    t = max(0.0, min(1.0, ((pos.x() - ax) * dx + (pos.y() - ay) * dy) / length))
+    proj = QtCore.QPointF(ax + t * dx, ay + t * dy)
+    return QtCore.QLineF(pos, proj).length()
+
+
+def insert_shape_point(item: dict[str, Any], after_index: int, pos: QtCore.QPointF) -> int:
+    points = ensure_shape_points(item)
+    nx, ny = scene_to_normalized(item, pos)
+    index = max(0, min(len(points), after_index + 1))
+    points.insert(index, _point(nx, ny))
+    if normalize_shape_kind((item.get("style") or {}).get("shape_kind")) == "freeform":
+        _apply_tangent_handles(points, index, shape_closed(item))
+    item["points"] = points
+    return index
+
+
+def remove_shape_point(item: dict[str, Any], index: int) -> bool:
+    points = ensure_shape_points(item)
+    kind = normalize_shape_kind((item.get("style") or {}).get("shape_kind"))
+    minimum = 2 if kind == "line" else 3
+    if index < 0 or index >= len(points) or len(points) <= minimum:
+        return False
+    points.pop(index)
+    item["points"] = points
+    return True

--- a/gremlin/ui/obs_overlay/templates.py
+++ b/gremlin/ui/obs_overlay/templates.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+
+import gremlin.shared_state
+
+from .model import new_widget
+
+
+def _at(widget_type: str, x: int, y: int, w: int | None = None, h: int | None = None, **fields):
+    item = new_widget(widget_type, x, y)
+    if w is not None:
+        item["w"] = w
+    if h is not None:
+        item["h"] = h
+    for key, value in fields.items():
+        if key == "style":
+            item["style"].update(value)
+        elif key in ("binding", "binding_y"):
+            item.setdefault(key, {}).update(value)
+        else:
+            item[key] = value
+    return item
+
+
+def dual_stick_hud():
+    """Left/right X/Y pads with a 1D axis bar under each stick."""
+    group = "dual-stick-hud"
+    stick = {"indicator_size": 16}
+    bar = {"orientation": "horizontal", "show_label": False, "indicator_size": 10}
+    items = [
+        _at(
+            "axis_stick_square",
+            80,
+            80,
+            210,
+            210,
+            group=group,
+            style={**stick, "axis_label_n": "F", "axis_label_s": "A", "axis_label_e": "R", "axis_label_w": "L"},
+        ),
+        _at("axis_bar", 80, 300, 210, 28, label="", group=group, style=bar),
+        _at(
+            "axis_stick_square",
+            360,
+            80,
+            210,
+            210,
+            group=group,
+            style={**stick, "axis_label_n": "U", "axis_label_s": "D", "axis_label_e": "R", "axis_label_w": "L"},
+        ),
+        _at("axis_bar", 360, 300, 210, 28, label="", group=group, style=bar),
+    ]
+    return items
+
+
+def gamepad_controller():
+    """Xbox-style pad silhouette; each control is independently bindable."""
+    group = "gamepad"
+    body = {"fill": "#2b313a", "border": "#111418", "border_width": 2.0, "opacity": 1.0}
+    stick = {"show_axis_labels": False, "indicator_size": 14, "fill": "#161b22", "border": "#3a424c"}
+    pill = {"shape": "pill", "font_size": 10, "fill": "#1a1f26", "fill_on": "#c44a2a", "border": "#5a221c"}
+    trigger = {"orientation": "horizontal", "show_label": False, "indicator_size": 8, "fill": "#1a1f26", "border": "#5a221c"}
+    face = {"shape": "circle", "font_size": 12, "fill": "#1a1f26", "border": "#3a424c"}
+    items = [
+        # Two hanging grips + a wider face so the outline reads as a controller, not a pill.
+        _at("panel", 40, 176, 250, 260, group=group, style={**body, "corner_radius": 120}),
+        _at("panel", 510, 176, 250, 260, group=group, style={**body, "corner_radius": 120}),
+        _at("panel", 88, 72, 624, 228, group=group, style={**body, "corner_radius": 56}),
+        # Analog triggers sit above digital bumpers, matching Xbox LT/RT then LB/RB.
+        _at("axis_bar", 112, 40, 124, 24, label="LT", group=group, style=trigger),
+        _at("axis_bar", 564, 40, 124, 24, label="RT", group=group, style=trigger),
+        _at("button", 112, 80, 124, 26, label="LB", group=group, style=pill),
+        _at("button", 564, 80, 124, 26, label="RB", group=group, style=pill),
+        # Left stick (upper left) and d-pad (lower left).
+        _at("axis_stick_circle", 116, 140, 132, 132, group=group, style=stick),
+        _at("button", 160, 276, 44, 20, label="L3", group=group, style={**pill, "font_size": 9}),
+        _at("hat", 144, 312, 100, 100, group=group, style={"show_axis_labels": False, "fill": "#161b22", "border": "#3a424c"}),
+        # View / Menu in the center spine.
+        _at("button", 332, 196, 52, 22, label="View", group=group, style={**pill, "font_size": 9}),
+        _at("button", 416, 196, 52, 22, label="Menu", group=group, style={**pill, "font_size": 9}),
+        # Right stick sits lower and inward, same as an Xbox pad.
+        _at("axis_stick_circle", 392, 268, 120, 120, group=group, style=stick),
+        _at("button", 430, 392, 44, 20, label="R3", group=group, style={**pill, "font_size": 9}),
+    ]
+    for label, x, y, color in (
+        ("Y", 572, 118, "#c9a227"),
+        ("X", 526, 164, "#2f5fad"),
+        ("B", 618, 164, "#c42f2f"),
+        ("A", 572, 210, "#2f8a44"),
+    ):
+        items.append(
+            _at("button", x, y, 46, 46, label=label, group=group, style={**face, "fill_on": color})
+        )
+    return items
+
+
+def throttle_pair():
+    group = "throttles"
+    left = _at("axis_bar", 40, 40, 36, 220, label="L", group=group, style={"orientation": "vertical"})
+    right = _at("axis_bar", 88, 40, 36, 220, label="R", group=group, style={"orientation": "vertical", "fill_bar": "#3dff9a"})
+    return [left, right]
+
+
+TEMPLATES = (
+    ("Dual-stick HUD", "Left/right sticks with a 1D axis bar under each", dual_stick_hud),
+    ("Gamepad", "Xbox-style controller with independently bindable controls", gamepad_controller),
+    ("Throttle pair", "Two vertical axis bars", throttle_pair),
+)
+
+
+def overlay_template_dir() -> str:
+    """Global (not profile-specific) folder for user-saved overlay templates."""
+    root = gremlin.shared_state.data_path
+    if not root:
+        root = os.path.join(os.path.expanduser("~"), "Joystick Gremlin Ex")
+    path = os.path.join(root, "overlay_templates")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _safe_filename(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", (name or "").strip()) or "template"
+    return cleaned[:80]
+
+
+def _write_template_file(path: str, name: str, widgets: list) -> str:
+    payload = {"name": (name or "").strip() or "template", "widgets": copy.deepcopy(widgets)}
+    folder = os.path.dirname(path)
+    if folder and not os.path.isdir(folder):
+        os.makedirs(folder, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+    return path
+
+
+def save_user_template(name: str, widgets: list) -> str:
+    folder = overlay_template_dir()
+    path = os.path.join(folder, f"{_safe_filename(name)}.json")
+    return _write_template_file(path, name.strip(), widgets)
+
+
+def update_user_template(filename: str, widgets: list) -> str:
+    """Overwrite a saved template file, keeping its display name."""
+    path = os.path.join(overlay_template_dir(), os.path.basename(filename))
+    name = os.path.splitext(os.path.basename(filename))[0]
+    if os.path.isfile(path):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle) or {}
+            if isinstance(data, dict) and data.get("name"):
+                name = str(data["name"])
+        except Exception:
+            pass
+    return _write_template_file(path, name, widgets)
+
+
+def delete_user_template(filename: str) -> bool:
+    path = os.path.join(overlay_template_dir(), os.path.basename(filename))
+    if not os.path.isfile(path):
+        return False
+    os.remove(path)
+    return True
+
+
+def list_user_templates() -> list[tuple[str, str, object, str]]:
+    """Return (title, tip, factory, filename) entries for saved templates."""
+    results: list[tuple[str, str, object, str]] = []
+    try:
+        names = sorted(os.listdir(overlay_template_dir()))
+    except OSError:
+        return results
+    folder = overlay_template_dir()
+    for fname in names:
+        if not fname.lower().endswith(".json"):
+            continue
+        path = os.path.join(folder, fname)
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        title = str(data.get("name") or os.path.splitext(fname)[0])
+        widgets = data.get("widgets") or []
+        if not isinstance(widgets, list):
+            continue
+        results.append((title, f"Saved template ({fname})", _make_factory(widgets), fname))
+    return results
+
+
+def _make_factory(widgets: list):
+    snapshot = copy.deepcopy(widgets)
+
+    def factory():
+        return copy.deepcopy(snapshot)
+
+    return factory

--- a/gremlin/ui/obs_overlay/touch.py
+++ b/gremlin/ui/obs_overlay/touch.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Live overlay touch / mouse → vJoy and GEX state writes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PySide6 import QtCore
+
+from .bindings import (
+    binding_for_axis,
+    binding_source,
+    read_widget_value,
+    toggle_state,
+    vjoy_binding_writable,
+    widget_accepts_touch,
+    widget_needs_xy,
+    write_axis,
+    write_button,
+    write_hat,
+)
+from .model import is_interactive_overlay
+from .widgets import value_from_point, widget_dirty_rect
+
+syslog = logging.getLogger("system")
+SPRING_TYPES = ("axis_stick_square", "axis_stick_circle", "axis_crosshair", "hat")
+
+
+class OverlayTouchHandler:
+    """Tracks pointer grabs on the live overlay and writes vJoy / states."""
+
+    def __init__(self, view):
+        self.view = view
+        self._grabs: dict[object, dict[str, Any]] = {}
+        self._logged_ignore = False
+
+    def enabled(self) -> bool:
+        return bool(getattr(self.view, "touch_output", False)) and is_interactive_overlay(self.view.page_canvas)
+
+    def _ignore(self, reason: str):
+        if self._logged_ignore:
+            return
+        self._logged_ignore = True
+        syslog.warning(
+            f"OBS OVERLAY: touch ignored ({reason}). "
+            "Check Interactive on the Overlay toolbar, then click the live overlay window (not the designer)."
+        )
+
+    def press(self, pointer_id, scene_pos: QtCore.QPointF) -> bool:
+        if not self.enabled() or pointer_id in self._grabs:
+            if not self.enabled():
+                self._ignore("Interactive is off")
+            return False
+        item = self.view.scene.hit_test(scene_pos.x(), scene_pos.y(), self.view.page_id)
+        if not item or not widget_accepts_touch(item):
+            if item and not widget_accepts_touch(item):
+                self._ignore(f"{item.get('type')} is not bound to vJoy or a state")
+            return False
+        if any(grab.get("item_id") == item["id"] for grab in self._grabs.values()):
+            return False
+        widget_type = item.get("type")
+        grab = {"item_id": item["id"], "type": widget_type, "held": False}
+        if widget_type == "button":
+            binding = item.get("binding") or {}
+            if binding_source(binding) == "state":
+                if toggle_state(binding) is None:
+                    return False
+                grab["kind"] = "state"
+                self._poke(item, read_widget_value(item))
+            else:
+                invert = bool(binding.get("invert"))
+                down = not invert
+                if not write_button(binding, down):
+                    return False
+                grab["kind"] = "button"
+                grab["held"] = True
+                grab["up_value"] = invert
+                self._poke(item, True)
+        else:
+            grab["kind"] = "value"
+            grab["spring"] = widget_type in SPRING_TYPES
+            self._apply_value(item, scene_pos)
+        self._grabs[pointer_id] = grab
+        return True
+
+    def move(self, pointer_id, scene_pos: QtCore.QPointF) -> bool:
+        grab = self._grabs.get(pointer_id)
+        if not grab or grab.get("kind") != "value":
+            return False
+        item = self.view.scene.widget_by_id(grab["item_id"], self.view.page_id)
+        if not item:
+            return False
+        self._apply_value(item, scene_pos)
+        return True
+
+    def release(self, pointer_id) -> bool:
+        grab = self._grabs.pop(pointer_id, None)
+        if not grab:
+            return False
+        item = self.view.scene.widget_by_id(grab["item_id"], self.view.page_id)
+        try:
+            if not item:
+                return True
+            if grab.get("kind") == "button" and grab.get("held"):
+                write_button(item.get("binding"), bool(grab.get("up_value")))
+                self._poke(item, False)
+            elif grab.get("kind") == "value" and grab.get("spring"):
+                self._spring(item)
+            return True
+        finally:
+            self._unlock(grab.get("item_id"))
+
+    def release_all(self):
+        for pointer_id in list(self._grabs):
+            self.release(pointer_id)
+
+    def _apply_value(self, item: dict[str, Any], scene_pos: QtCore.QPointF):
+        mapped = value_from_point(item, scene_pos.x(), scene_pos.y())
+        widget_type = item.get("type")
+        if widget_type == "hat":
+            direction = mapped if isinstance(mapped, tuple) else (0, 0)
+            write_hat(item.get("binding"), (int(direction[0]), int(direction[1])))
+            self._poke(item, (int(direction[0]), int(direction[1])))
+            return
+        if widget_needs_xy(widget_type):
+            x_val, y_val = mapped if isinstance(mapped, tuple) else (0.0, 0.0)
+            x_bind = binding_for_axis(item, "x")
+            y_bind = binding_for_axis(item, "y")
+            if vjoy_binding_writable(x_bind):
+                write_axis(x_bind, float(x_val))
+            if vjoy_binding_writable(y_bind):
+                write_axis(y_bind, float(y_val))
+            self._poke(item, (float(x_val), float(y_val)))
+            return
+        axis = float(mapped) if isinstance(mapped, (int, float)) else 0.0
+        write_axis(item.get("binding"), axis)
+        self._poke(item, axis)
+
+    def _spring(self, item: dict[str, Any]):
+        widget_type = item.get("type")
+        if widget_type == "hat":
+            write_hat(item.get("binding"), (0, 0))
+            self._poke(item, (0, 0))
+            return
+        if widget_needs_xy(widget_type):
+            x_bind = binding_for_axis(item, "x")
+            y_bind = binding_for_axis(item, "y")
+            if vjoy_binding_writable(x_bind):
+                write_axis(x_bind, 0.0)
+            if vjoy_binding_writable(y_bind):
+                write_axis(y_bind, 0.0)
+            self._poke(item, (0.0, 0.0))
+
+    def _poke(self, item: dict[str, Any], value):
+        bus = getattr(self.view, "bus", None)
+        if bus is not None:
+            bus.poke(item.get("id"), value, lock=True)
+        else:
+            self.view.update(widget_dirty_rect(item).toRect())
+
+    def _unlock(self, widget_id: str | None):
+        bus = getattr(self.view, "bus", None)
+        if bus is not None:
+            bus.unlock(widget_id)

--- a/gremlin/ui/obs_overlay/widgets.py
+++ b/gremlin/ui/obs_overlay/widgets.py
@@ -1,0 +1,1366 @@
+# -*- coding: utf-8; -*-
+
+# Based in part on original Joystick Gremlin work by Lionel Ott and other contributors - Gremlin Ex is (C) EMCS 2026
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any
+
+from PySide6 import QtCore, QtGui
+
+from .model import is_onscreen_mode, normalize_background_mode
+from .shapes import normalize_shape_kind, shape_path
+
+
+def qcolor(value, default="#ffffff") -> QtGui.QColor:
+    color = QtGui.QColor(value if value else default)
+    if not color.isValid():
+        color = QtGui.QColor(default)
+    return color
+
+
+def chroma_fill_color(canvas: dict[str, Any] | None) -> QtGui.QColor:
+    return qcolor((canvas or {}).get("chroma_color"), "#00FF00")
+
+
+def live_window_is_layered(canvas: dict[str, Any] | None, designer: bool = False) -> bool:
+    """True when the live overlay must composite onto the desktop (not a black fill)."""
+    if designer:
+        return False
+    if is_onscreen_mode(canvas):
+        return True
+    return chroma_fill_color(canvas).alpha() < 255
+
+
+def _font_scale(item: dict[str, Any] | None) -> float:
+    if not item:
+        return 1.0
+    style = item.get("style") or {}
+    if not style.get("auto_scale_font"):
+        return 1.0
+    base = float(style.get("font_scale_base") or 0)
+    if base <= 1:
+        base = 100.0
+    current = min(float(item.get("w") or 1), float(item.get("h") or 1))
+    return max(0.35, min(6.0, current / base))
+
+
+def _scaled_font_px(style: dict[str, Any], key: str, item: dict[str, Any] | None, default: int = 11) -> int:
+    size = style.get(key)
+    if size is None and key.startswith("axis_"):
+        size = style.get("font_size")
+    px = float(size if size is not None else default)
+    return max(6, int(round(px * _font_scale(item))))
+
+
+def effective_font_size(item: dict[str, Any] | None, key: str = "font_size", default: int = 11) -> int:
+    """Pixel size actually drawn, including auto-scale."""
+    style = (item or {}).get("style") or {}
+    return _scaled_font_px(style, key, item, default)
+
+
+def _make_font(family: str | None, size, bold: bool) -> QtGui.QFont:
+    font = QtGui.QFont()
+    font.setFamily(family or "Segoe UI")
+    font.setPixelSize(max(6, int(size or 11)))
+    font.setBold(bool(bold))
+    font.setStyleStrategy(QtGui.QFont.PreferAntialias)
+    return font
+
+
+def _font(style: dict[str, Any], item: dict[str, Any] | None = None) -> QtGui.QFont:
+    return _make_font(style.get("font_family"), _scaled_font_px(style, "font_size", item), style.get("font_bold", True))
+
+
+def _axis_label_font(style: dict[str, Any], item: dict[str, Any] | None = None) -> QtGui.QFont:
+    return _make_font(
+        style.get("axis_label_font_family") or style.get("font_family"),
+        _scaled_font_px(style, "axis_label_font_size", item),
+        style.get("axis_label_font_bold", style.get("font_bold", True)),
+    )
+
+
+def _pen(color, width=1.0) -> QtGui.QPen:
+    pen = QtGui.QPen(qcolor(color))
+    pen.setWidthF(float(width))
+    pen.setJoinStyle(QtCore.Qt.RoundJoin)
+    pen.setCapStyle(QtCore.Qt.RoundCap)
+    return pen
+
+
+def _clamp(value: float, lo: float = -1.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, value))
+
+
+def _opacity(style: dict[str, Any]) -> float:
+    try:
+        value = style.get("opacity")
+        if value is None:
+            return 1.0
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _deadzone(value: float, style: dict) -> float:
+    zone = float(style.get("deadzone") or 0.0)
+    if zone > 0 and abs(value) < zone:
+        return 0.0
+    return value
+
+
+def _xy(value) -> tuple[float, float]:
+    if isinstance(value, (tuple, list)) and len(value) >= 2:
+        return _clamp(float(value[0])), _clamp(float(value[1]))
+    if isinstance(value, (int, float)):
+        return _clamp(float(value)), 0.0
+    return 0.0, 0.0
+
+
+def _axis(value) -> float:
+    if isinstance(value, (tuple, list)):
+        return _clamp(float(value[0] if value else 0.0))
+    if isinstance(value, (int, float)):
+        return _clamp(float(value))
+    return 0.0
+
+
+def _pressed(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return abs(value) > 0.5
+    if isinstance(value, (tuple, list)) and value:
+        return any(abs(float(v)) > 0.15 for v in value)
+    return False
+
+
+def widget_rect(item: dict[str, Any]) -> QtCore.QRectF:
+    return QtCore.QRectF(item["x"], item["y"], item["w"], item["h"])
+
+
+def _inner_rect(rect: QtCore.QRectF, style: dict[str, Any]) -> QtCore.QRectF:
+    inset = max(0.5, float(style.get("border_width") or 2) * 0.5)
+    return rect.adjusted(inset, inset, -inset, -inset)
+
+
+def _corner_radius(style: dict[str, Any], default: float = 6.0) -> float:
+    try:
+        value = style.get("corner_radius")
+        if value is None:
+            return default
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _clip_rounded(painter: QtGui.QPainter, rect: QtCore.QRectF, style: dict[str, Any], radius: float) -> QtCore.QRectF:
+    inner = _inner_rect(rect, style)
+    inset = max(0.5, float(style.get("border_width") or 2) * 0.5)
+    inner_r = max(0.0, radius - inset)
+    if inner_r > 0:
+        painter.setClipPath(_rounded(inner, inner_r))
+    else:
+        painter.setClipRect(inner)
+    return inner
+
+
+def _with_grid_fade(painter: QtGui.QPainter, bounds: QtCore.QRectF, style: dict[str, Any], circular: bool, draw_cb):
+    if not style.get("grid_fade") or bounds.width() < 4 or bounds.height() < 4:
+        draw_cb(painter)
+        return
+    width = max(1, int(math.ceil(bounds.width())))
+    height = max(1, int(math.ceil(bounds.height())))
+    pm = QtGui.QPixmap(width, height)
+    pm.fill(QtCore.Qt.transparent)
+    gp = QtGui.QPainter(pm)
+    gp.translate(-bounds.left(), -bounds.top())
+    draw_cb(gp)
+    gp.setCompositionMode(QtGui.QPainter.CompositionMode_DestinationIn)
+    radius = min(bounds.width(), bounds.height()) / 2.0 if circular else max(bounds.width(), bounds.height()) / 2.0
+    gradient = QtGui.QRadialGradient(bounds.center(), max(1.0, radius))
+    gradient.setColorAt(0.0, QtGui.QColor(0, 0, 0, 255))
+    gradient.setColorAt(0.55, QtGui.QColor(0, 0, 0, 255))
+    gradient.setColorAt(1.0, QtGui.QColor(0, 0, 0, 0))
+    gp.fillRect(bounds, gradient)
+    gp.end()
+    painter.drawPixmap(bounds.topLeft(), pm)
+
+
+def _draw_square_grid(painter: QtGui.QPainter, inner: QtCore.QRectF, style: dict[str, Any]):
+    if not style.get("show_grid", True):
+        return
+
+    def _lines(target: QtGui.QPainter):
+        target.setPen(_pen(style.get("grid"), style.get("grid_width") or 1))
+        for i in range(1, 4):
+            t = i / 4.0
+            target.drawLine(
+                QtCore.QPointF(inner.left() + inner.width() * t, inner.top()),
+                QtCore.QPointF(inner.left() + inner.width() * t, inner.bottom()),
+            )
+            target.drawLine(
+                QtCore.QPointF(inner.left(), inner.top() + inner.height() * t),
+                QtCore.QPointF(inner.right(), inner.top() + inner.height() * t),
+            )
+
+    _with_grid_fade(painter, inner, style, False, _lines)
+
+
+def _draw_ring_grid(painter: QtGui.QPainter, circle: QtCore.QRectF, style: dict[str, Any], rings: int):
+    if not style.get("show_grid", True):
+        return
+    rings = max(1, int(rings))
+
+    def _rings(target: QtGui.QPainter):
+        target.setBrush(QtCore.Qt.NoBrush)
+        target.setPen(_pen(style.get("grid"), style.get("grid_width") or 1))
+        for i in range(1, rings + 1):
+            t = i / float(rings)
+            inset = (1.0 - t) * min(circle.width(), circle.height()) / 2.0
+            target.drawEllipse(circle.adjusted(inset, inset, -inset, -inset))
+
+    _with_grid_fade(painter, circle, style, True, _rings)
+
+
+def _draw_crosshairs(painter: QtGui.QPainter, bounds: QtCore.QRectF, style: dict[str, Any]):
+    if not style.get("show_center_line", True):
+        return
+    painter.setPen(_pen(style.get("crosshair"), max(1.0, float(style.get("grid_width") or 1.2))))
+    painter.drawLine(QtCore.QPointF(bounds.center().x(), bounds.top()), QtCore.QPointF(bounds.center().x(), bounds.bottom()))
+    painter.drawLine(QtCore.QPointF(bounds.left(), bounds.center().y()), QtCore.QPointF(bounds.right(), bounds.center().y()))
+
+
+def widget_dirty_rect(item: dict[str, Any]) -> QtCore.QRect:
+    """Widget bounds plus label overflow, for partial updates."""
+    rect = widget_rect(item).toAlignedRect()
+    pad = max(28, _scaled_font_px(item.get("style") or {}, "font_size", item) + 12)
+    return rect.adjusted(-pad, -pad, pad, pad)
+
+
+def _draw_label(painter: QtGui.QPainter, item: dict[str, Any], rect: QtCore.QRectF, color=None):
+    style = item.get("style") or {}
+    if not style.get("show_label", True):
+        return
+    text = item.get("label") or ""
+    if not text:
+        return
+    painter.save()
+    painter.setPen(qcolor(color or style.get("font_color"), "#f4efe4"))
+    painter.setFont(_font(style, item))
+    label_rect = rect.adjusted(
+        float(style.get("label_offset_x") or 0),
+        float(style.get("label_offset_y") or 0),
+        float(style.get("label_offset_x") or 0),
+        float(style.get("label_offset_y") or 0),
+    )
+    painter.drawText(label_rect, int(QtCore.Qt.AlignCenter), text)
+    painter.restore()
+
+
+def _rounded(rect: QtCore.QRectF, radius: float) -> QtGui.QPainterPath:
+    path = QtGui.QPainterPath()
+    path.addRoundedRect(rect, radius, radius)
+    return path
+
+
+def paint_shape(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    kind = normalize_shape_kind(style.get("shape_kind"))
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    fill = qcolor(style.get("fill"), "#101820")
+    closed = bool(style.get("shape_closed")) if kind == "line" else True
+    if kind == "line" and not closed:
+        painter.setBrush(QtCore.Qt.NoBrush)
+    else:
+        painter.setBrush(fill)
+    painter.drawPath(shape_path(item))
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+_widget_image_cache: dict[str, QtGui.QPixmap] = {}
+
+
+def _widget_image_pixmap(path: str) -> QtGui.QPixmap:
+    if not path:
+        return QtGui.QPixmap()
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        return QtGui.QPixmap()
+    key = f"{path}|{mtime}"
+    pixmap = _widget_image_cache.get(key)
+    if pixmap is not None and not pixmap.isNull():
+        return pixmap
+    image = QtGui.QImage(path)
+    if image.isNull():
+        return QtGui.QPixmap()
+    if image.hasAlphaChannel():
+        image = image.convertToFormat(QtGui.QImage.Format_ARGB32_Premultiplied)
+    pixmap = QtGui.QPixmap.fromImage(image)
+    if len(_widget_image_cache) > 24:
+        _widget_image_cache.clear()
+    _widget_image_cache[key] = pixmap
+    return pixmap
+
+
+def paint_image(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    fill = qcolor(style.get("fill"), "#00000000")
+    border_w = float(style.get("border_width") or 0)
+    if fill.alpha() > 0:
+        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(fill)
+        painter.drawRect(rect)
+    path = style.get("image_path") or ""
+    pixmap = _widget_image_pixmap(path)
+    if pixmap.isNull():
+        painter.setPen(_pen(style.get("border"), max(1.0, border_w or 1.5)))
+        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.drawRect(rect)
+        painter.setPen(qcolor(style.get("font_color"), "#f4efe4"))
+        painter.drawText(rect, int(QtCore.Qt.AlignCenter), "No image")
+        _draw_label(painter, item, rect)
+        painter.restore()
+        return
+    keep_aspect = bool(style.get("image_keep_aspect", True))
+    mode = QtCore.Qt.KeepAspectRatio if keep_aspect else QtCore.Qt.IgnoreAspectRatio
+    painter.setRenderHint(QtGui.QPainter.SmoothPixmapTransform, True)
+    scaled = pixmap.scaled(rect.size().toSize(), mode, QtCore.Qt.SmoothTransformation)
+    target = QtCore.QRectF(
+        rect.center().x() - scaled.width() / 2.0,
+        rect.center().y() - scaled.height() / 2.0,
+        scaled.width(),
+        scaled.height(),
+    )
+    painter.drawPixmap(target.toRect(), scaled)
+    if border_w > 0:
+        painter.setBrush(QtCore.Qt.NoBrush)
+        painter.setPen(_pen(style.get("border"), border_w))
+        painter.drawRect(rect)
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+_streamdeck_pm_cache: dict[tuple, QtGui.QPixmap] = {}
+
+
+def streamdeck_preferred_size(device_type=None) -> tuple[int, int]:
+    """Bezel size that matches a Stream Deck key grid (and Plus dials)."""
+    try:
+        from gremlin.ui.streamdeck_device import device_grid_size, parse_streamdeck_device_type
+
+        grid = device_grid_size(device_type)
+        dtype = parse_streamdeck_device_type(device_type)
+    except Exception:
+        grid = None
+        dtype = None
+    cols, rows = grid or (5, 3)
+    plus = dtype in (7, 8)
+    key = 52
+    gap = 6
+    pad = 18
+    width = pad * 2 + cols * key + (cols - 1) * gap
+    height = pad * 2 + rows * key + (rows - 1) * gap
+    if plus:
+        height += gap + max(18, int(key * 0.42)) + gap + max(28, int(key * 0.62))
+    return (int(width), int(height))
+
+
+def _streamdeck_slot_pixmap(slot_item, pressed: bool, side: int, lcd: bool = False) -> QtGui.QPixmap:
+    if slot_item is None:
+        return QtGui.QPixmap()
+    width = 200 if lcd else max(24, int(side))
+    height = 100 if lcd else width
+    key = (
+        id(slot_item),
+        bool(pressed),
+        int(width),
+        int(height),
+        getattr(slot_item, "image_path", "") or "",
+        getattr(slot_item, "image_pressed_path", "") or "",
+        getattr(slot_item, "title", "") or "",
+        getattr(slot_item, "title_pressed", "") or "",
+        getattr(slot_item, "bg_color", "") or "",
+        getattr(slot_item, "bg_color_pressed", "") or "",
+    )
+    cached = _streamdeck_pm_cache.get(key)
+    if cached is not None and not cached.isNull():
+        return cached
+    pixmap = QtGui.QPixmap()
+    try:
+        from gremlin.ui.streamdeck_surface import compose_key_pixmap, item_needs_composite
+
+        kind = getattr(slot_item, "kind", "") or ""
+        use_lcd = lcd or kind in ("dial", "dial_press")
+        if item_needs_composite(slot_item, pressed=pressed) or (
+            pressed and item_needs_composite(slot_item, pressed=False)
+        ) or (use_lcd and (getattr(slot_item, "bg_color", "") or getattr(slot_item, "bg_color_pressed", ""))):
+            if use_lcd:
+                pixmap = compose_key_pixmap(slot_item, pressed=pressed, width=200, height=100)
+            else:
+                pixmap = compose_key_pixmap(slot_item, size=max(72, width), pressed=pressed)
+        if pixmap is None or pixmap.isNull():
+            from gremlin.ui.streamdeck_surface import resolve_paint_image, resolve_paint_image_pressed
+
+            raw = resolve_paint_image_pressed(slot_item) if pressed else resolve_paint_image(slot_item)
+            if raw and str(raw).startswith("data:") and "," in str(raw):
+                import base64
+
+                data = base64.b64decode(str(raw).split(",", 1)[1])
+                pixmap = QtGui.QPixmap()
+                pixmap.loadFromData(data)
+            else:
+                path = ""
+                if pressed:
+                    path = getattr(slot_item, "image_pressed_path", "") or getattr(slot_item, "image_path", "") or ""
+                else:
+                    path = getattr(slot_item, "image_path", "") or ""
+                if path:
+                    pixmap = QtGui.QPixmap(path)
+    except Exception:
+        pixmap = QtGui.QPixmap()
+    if len(_streamdeck_pm_cache) > 64:
+        _streamdeck_pm_cache.clear()
+    _streamdeck_pm_cache[key] = pixmap
+    return pixmap
+
+
+def _streamdeck_message_rect(painter: QtGui.QPainter, item: dict[str, Any], rect: QtCore.QRectF, text: str):
+    style = item.get("style") or {}
+    painter.setPen(qcolor(style.get("font_color"), "#f4efe4"))
+    painter.drawText(rect.adjusted(8, 8, -8, -8), int(QtCore.Qt.AlignCenter | QtCore.Qt.TextWordWrap), text)
+    _draw_label(painter, item, rect)
+
+
+def paint_streamdeck(painter: QtGui.QPainter, item: dict[str, Any], value):
+    """Draw a connected Stream Deck key grid (and Plus dials) on the overlay."""
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+    painter.setRenderHint(QtGui.QPainter.SmoothPixmapTransform, True)
+
+    radius = float(style.get("corner_radius") or 0)
+    fill = qcolor(style.get("fill"), "#1a1d22")
+    border_w = float(style.get("border_width") or 0)
+    show_bezel = bool(style.get("show_bezel", True))
+    if show_bezel:
+        if border_w > 0:
+            painter.setPen(_pen(style.get("border"), border_w))
+        else:
+            painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(fill if fill.alpha() > 0 else QtCore.Qt.NoBrush)
+        if radius > 0:
+            painter.drawRoundedRect(rect, radius, radius)
+        else:
+            painter.drawRect(rect)
+        if radius > 0:
+            clip = QtGui.QPainterPath()
+            clip.addRoundedRect(rect, radius, radius)
+            painter.setClipPath(clip)
+    elif fill.alpha() > 0:
+        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(fill)
+        painter.drawRect(rect)
+
+    try:
+        from gremlin.ui.streamdeck_device import (
+            StreamDeckBridge,
+            device_grid_size,
+            friendly_streamdeck_name,
+            is_streamdeck_designer_supported,
+            make_slot_key,
+            normalize_page,
+            parse_streamdeck_device_type,
+        )
+
+        bridge = StreamDeckBridge()
+        device_id = bridge.resolve_overlay_device_id(str(style.get("streamdeck_device_id") or ""))
+        info = bridge.devices.get(device_id, {}) if device_id else {}
+        dtype = parse_streamdeck_device_type(info.get("type")) if info else None
+        if not device_id:
+            _streamdeck_message_rect(
+                painter,
+                item,
+                rect,
+                "No Stream Deck connected" if not bridge.plugin_is_connected else "Select a Stream Deck",
+            )
+            painter.restore()
+            return
+        if device_id not in bridge.devices:
+            label = friendly_streamdeck_name("", None, device_id)
+            _streamdeck_message_rect(painter, item, rect, f"Waiting for {label}")
+            painter.restore()
+            return
+        if not is_streamdeck_designer_supported(dtype):
+            label = friendly_streamdeck_name(info.get("name"), info.get("type"), device_id)
+            _streamdeck_message_rect(painter, item, rect, f"{label}\nnot supported")
+            painter.restore()
+            return
+
+        grid = device_grid_size(dtype) or (5, 3)
+        cols, rows = int(grid[0]), int(grid[1])
+        plus = dtype in (7, 8)
+        follow = bool(style.get("streamdeck_follow_page", True))
+        page = bridge.get_active_page(device_id) if follow else normalize_page(style.get("streamdeck_page") or 1)
+        slots = bridge.overlay_slots(device_id, page)
+        held = bridge.held_slot_keys(device_id)
+
+        pad = 10.0 if show_bezel else 2.0
+        inner = rect.adjusted(pad, pad, -pad, -pad)
+        lcd_frac = 0.42
+        dial_frac = 0.62
+        units = float(rows) + (lcd_frac + dial_frac if plus else 0.0)
+        gap = max(2.0, min(inner.width() / max(1, cols * 10), inner.height() / max(1, units * 10)))
+        extra_gaps = 2.0 if plus else 0.0
+        key = min(
+            (inner.width() - gap * max(0, cols - 1)) / max(1, cols),
+            (inner.height() - gap * (max(0, rows - 1) + extra_gaps)) / max(0.5, units),
+        )
+        lcd_h = key * lcd_frac if plus else 0.0
+        dial_h = key * dial_frac if plus else 0.0
+        keys_h = rows * key + max(0, rows - 1) * gap
+        grid_w = cols * key + max(0, cols - 1) * gap
+        grid_h = keys_h + ((2.0 * gap + lcd_h + dial_h) if plus else 0.0)
+        ox = inner.center().x() - grid_w / 2.0
+        oy = inner.center().y() - grid_h / 2.0
+        key_r = max(2.0, min(8.0, key * 0.12))
+        empty_fill = qcolor("#111318")
+        empty_pen = QtGui.QPen(qcolor("#2a3038"), 1)
+
+        def _key_rect(row: int, col: int) -> QtCore.QRectF:
+            return QtCore.QRectF(ox + col * (key + gap), oy + row * (key + gap), key, key)
+
+        for row in range(rows):
+            for col in range(cols):
+                cell = _key_rect(row, col)
+                slot_item = slots.get(("button", row, col))
+                pressed = make_slot_key("button", row, col) in held
+                pixmap = _streamdeck_slot_pixmap(slot_item, pressed, max(24, int(key)))
+                if pixmap.isNull():
+                    painter.setPen(empty_pen)
+                    painter.setBrush(empty_fill)
+                    painter.drawRoundedRect(cell, key_r, key_r)
+                else:
+                    path = QtGui.QPainterPath()
+                    path.addRoundedRect(cell, key_r, key_r)
+                    painter.save()
+                    painter.setClipPath(path)
+                    scaled = pixmap.scaled(cell.size().toSize(), QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.SmoothTransformation)
+                    painter.drawPixmap(cell.toRect(), scaled)
+                    painter.restore()
+                    if pressed:
+                        painter.setPen(QtCore.Qt.NoPen)
+                        painter.setBrush(QtGui.QColor(255, 255, 255, 36))
+                        painter.drawRoundedRect(cell, key_r, key_r)
+
+        if plus:
+            lcd_y = oy + keys_h + gap
+            dial_y = lcd_y + lcd_h + gap
+            lcd_w = key * 0.92
+            for col in range(min(4, cols)):
+                cx = ox + col * (key + gap) + key / 2.0
+                lcd = QtCore.QRectF(cx - lcd_w / 2.0, lcd_y, lcd_w, lcd_h)
+                slot_item = slots.get(("dial_press", 0, col))
+                pixmap = _streamdeck_slot_pixmap(slot_item, False, max(24, int(key)), lcd=True)
+                painter.setPen(empty_pen)
+                painter.setBrush(empty_fill)
+                painter.drawRoundedRect(lcd, 3, 3)
+                if not pixmap.isNull():
+                    scaled = pixmap.scaled(lcd.size().toSize(), QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.SmoothTransformation)
+                    painter.drawPixmap(lcd.toRect(), scaled)
+                dial_r = min(key, dial_h) * 0.42
+                center = QtCore.QPointF(cx, dial_y + dial_h / 2.0)
+                pressed = make_slot_key("dial_press", 0, col) in held
+                painter.setPen(empty_pen)
+                painter.setBrush(qcolor("#2a2f36") if not pressed else qcolor("#4a5560"))
+                painter.drawEllipse(center, dial_r, dial_r)
+                painter.setBrush(qcolor("#111318"))
+                painter.drawEllipse(center, dial_r * 0.38, dial_r * 0.38)
+    except Exception:
+        _streamdeck_message_rect(painter, item, rect, "Stream Deck unavailable")
+        painter.restore()
+        return
+
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def paint_panel(painter: QtGui.QPainter, item: dict[str, Any], value):
+    paint_shape(painter, item, value)
+
+
+def paint_label(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    fill = qcolor(style.get("fill"), "#00000000")
+    border_w = float(style.get("border_width") or 0)
+    if fill.alpha() > 0 or border_w > 0:
+        if border_w > 0:
+            painter.setPen(_pen(style.get("border"), border_w))
+        else:
+            painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(fill if fill.alpha() > 0 else QtCore.Qt.NoBrush)
+        radius = float(style.get("corner_radius") or 0)
+        if radius > 0:
+            painter.drawRoundedRect(rect, radius, radius)
+        else:
+            painter.drawRect(rect)
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def paint_button(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    on = _pressed(value)
+    fill = style.get("fill_on") if on else style.get("fill")
+    border = style.get("border_on") if on else style.get("border")
+    shape = (style.get("shape") or "rounded").casefold()
+    radius = float(style.get("corner_radius") or 6)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    painter.setPen(_pen(border, style.get("border_width") or 2))
+    painter.setBrush(qcolor(fill, "#3a1518"))
+    if shape == "circle":
+        side = min(rect.width(), rect.height())
+        painter.drawEllipse(QtCore.QRectF(rect.center().x() - side / 2, rect.center().y() - side / 2, side, side))
+    elif shape == "pill":
+        painter.drawPath(_rounded(rect, rect.height() / 2))
+    elif shape == "rect":
+        painter.drawRect(rect)
+    else:
+        painter.drawPath(_rounded(rect, radius))
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def _axis_label_spread(style: dict[str, Any]) -> float:
+    try:
+        value = style.get("axis_label_spread")
+        if value is None:
+            return 1.0
+        return max(0.0, min(100.0, float(value))) / 100.0
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _draw_axis_label_at(painter: QtGui.QPainter, text: str, x: float, y: float, metrics: QtGui.QFontMetrics):
+    if not text:
+        return
+    bounds = metrics.tightBoundingRect(text)
+    # tightBoundingRect is relative to the baseline; place ink centered on (x, y).
+    painter.drawText(
+        QtCore.QPointF(x - bounds.x() - bounds.width() / 2.0, y - bounds.y() - bounds.height() / 2.0),
+        text,
+    )
+
+
+def _draw_axis_labels(painter: QtGui.QPainter, item: dict[str, Any], rect: QtCore.QRectF, ends: str | None = "all"):
+    style = item.get("style") or {}
+    if not style.get("show_axis_labels", True):
+        return
+    painter.save()
+    painter.setPen(qcolor(style.get("axis_label_font_color") or style.get("font_color"), "#f4efe4"))
+    painter.setFont(_axis_label_font(style, item))
+    metrics = painter.fontMetrics()
+    spread = _axis_label_spread(style)
+    edge_pad = max(0.0, float(style.get("border_width") or 2)) * 0.5 + 4.0
+    cx = rect.center().x()
+    cy = rect.center().y()
+    ns = ends in (None, "all", "ns")
+    ew = ends in (None, "all", "ew")
+
+    def _reach(text: str, vertical: bool) -> float:
+        bounds = metrics.tightBoundingRect(text or "X")
+        half = (bounds.height() if vertical else bounds.width()) / 2.0
+        span = (rect.height() if vertical else rect.width()) / 2.0
+        return max(0.0, span - edge_pad - half)
+
+    if ns:
+        north = style.get("axis_label_n") or ""
+        south = style.get("axis_label_s") or ""
+        _draw_axis_label_at(painter, north, cx, cy - spread * _reach(north, True), metrics)
+        _draw_axis_label_at(painter, south, cx, cy + spread * _reach(south, True), metrics)
+    if ew:
+        east = style.get("axis_label_e") or ""
+        west = style.get("axis_label_w") or ""
+        _draw_axis_label_at(painter, west, cx - spread * _reach(west, False), cy, metrics)
+        _draw_axis_label_at(painter, east, cx + spread * _reach(east, False), cy, metrics)
+    painter.restore()
+
+
+def _indicator(painter: QtGui.QPainter, center: QtCore.QPointF, style: dict[str, Any], glow=None):
+    size = float(style.get("indicator_size") or 12)
+    color = qcolor(style.get("indicator"), "#ff5a3c")
+    shape = (style.get("indicator_shape") or "circle").casefold()
+    if glow is None:
+        glow = bool(style.get("show_dot_shadow", True))
+    painter.setPen(QtCore.Qt.NoPen)
+    if glow:
+        glow_color = QtGui.QColor(color)
+        glow_color.setAlpha(80)
+        painter.setBrush(glow_color)
+        extra = size * 0.45
+        if shape == "square":
+            painter.drawRect(QtCore.QRectF(center.x() - size / 2 - extra / 2, center.y() - size / 2 - extra / 2, size + extra, size + extra))
+        else:
+            painter.drawEllipse(center, size * 0.95, size * 0.95)
+    painter.setBrush(color)
+    if shape == "square":
+        painter.drawRect(QtCore.QRectF(center.x() - size / 2, center.y() - size / 2, size, size))
+    else:
+        painter.drawEllipse(center, size / 2, size / 2)
+
+
+def _draw_dot_crosshair(painter: QtGui.QPainter, bounds: QtCore.QRectF, cx: float, cy: float, style: dict[str, Any], circular: bool = False):
+    """Horizontal/vertical lines through the moving dot, in the dot color."""
+    if not style.get("show_dot_crosshair"):
+        return
+    painter.setPen(_pen(style.get("indicator"), style.get("grid_width") or 1.0))
+    if circular:
+        origin = bounds.center()
+        radius = min(bounds.width(), bounds.height()) / 2.0
+        dx2 = radius * radius - (cy - origin.y()) ** 2
+        dy2 = radius * radius - (cx - origin.x()) ** 2
+        if dx2 > 0.5:
+            dx = math.sqrt(dx2)
+            painter.drawLine(QtCore.QPointF(origin.x() - dx, cy), QtCore.QPointF(origin.x() + dx, cy))
+        if dy2 > 0.5:
+            dy = math.sqrt(dy2)
+            painter.drawLine(QtCore.QPointF(cx, origin.y() - dy), QtCore.QPointF(cx, origin.y() + dy))
+        return
+    painter.drawLine(QtCore.QPointF(bounds.left(), cy), QtCore.QPointF(bounds.right(), cy))
+    painter.drawLine(QtCore.QPointF(cx, bounds.top()), QtCore.QPointF(cx, bounds.bottom()))
+
+
+def _angle_step(style: dict[str, Any]) -> int:
+    try:
+        step = int(style.get("angle_step") or 0)
+    except (TypeError, ValueError):
+        return 0
+    return step if step in (15, 30, 45) else 0
+
+
+def _draw_angle_lines(painter: QtGui.QPainter, center: QtCore.QPointF, radius: float, style: dict[str, Any]):
+    step = _angle_step(style)
+    if not step:
+        return
+    painter.setPen(_pen(style.get("grid"), style.get("grid_width") or 1))
+    for deg in range(0, 360, step):
+        angle = math.radians(deg)
+        painter.drawLine(center, QtCore.QPointF(center.x() + math.cos(angle) * radius, center.y() + math.sin(angle) * radius))
+
+
+def _caption(painter: QtGui.QPainter, item: dict[str, Any], rect: QtCore.QRectF, vertical: bool):
+    if not (item.get("style") or {}).get("show_label", True) or not item.get("label"):
+        return
+    if vertical:
+        _draw_label(painter, item, QtCore.QRectF(rect.x(), rect.bottom() + 2, rect.width(), 18))
+    else:
+        _draw_label(painter, item, QtCore.QRectF(rect.x(), rect.y() - 18, rect.width(), 16))
+
+
+def paint_axis_bar(painter: QtGui.QPainter, item: dict[str, Any], value):
+    """1D pad: track + moving dot, horizontal or vertical."""
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    axis = _deadzone(_axis(value), style)
+    if style.get("invert_display"):
+        axis = -axis
+    vertical = (style.get("orientation") or "vertical").casefold() != "horizontal"
+    radius = _corner_radius(style, 6.0)
+    painter.save()
+    painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+    painter.setOpacity(_opacity(style))
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    painter.setBrush(qcolor(style.get("fill"), "#121826"))
+    if radius > 0:
+        painter.drawPath(_rounded(rect, radius))
+    else:
+        painter.drawRect(rect)
+    inner = _clip_rounded(painter, rect, style, radius)
+    if style.get("show_grid", True):
+
+        def _bar_grid(target: QtGui.QPainter):
+            target.setPen(_pen(style.get("grid"), style.get("grid_width") or 1))
+            if vertical:
+                for i in range(1, 4):
+                    t = i / 4.0
+                    y = inner.top() + inner.height() * t
+                    target.drawLine(QtCore.QPointF(inner.left(), y), QtCore.QPointF(inner.right(), y))
+            else:
+                for i in range(1, 4):
+                    t = i / 4.0
+                    x = inner.left() + inner.width() * t
+                    target.drawLine(QtCore.QPointF(x, inner.top()), QtCore.QPointF(x, inner.bottom()))
+
+        _with_grid_fade(painter, inner, style, False, _bar_grid)
+    if style.get("show_center_line", True):
+        painter.setPen(_pen(style.get("crosshair"), 1.2))
+        if vertical:
+            painter.drawLine(QtCore.QPointF(inner.center().x(), inner.top()), QtCore.QPointF(inner.center().x(), inner.bottom()))
+        else:
+            painter.drawLine(QtCore.QPointF(inner.left(), inner.center().y()), QtCore.QPointF(inner.right(), inner.center().y()))
+    if vertical:
+        t = (axis + 1.0) / 2.0
+        cx = inner.center().x()
+        cy = inner.bottom() - t * inner.height()
+    else:
+        t = (axis + 1.0) / 2.0
+        cx = inner.left() + t * inner.width()
+        cy = inner.center().y()
+    _draw_dot_crosshair(painter, inner, cx, cy, style)
+    _indicator(painter, QtCore.QPointF(cx, cy), style)
+    painter.setClipping(False)
+    _draw_axis_labels(painter, item, rect, ends="ns" if vertical else "ew")
+    _caption(painter, item, rect, vertical)
+    painter.restore()
+
+
+def paint_axis_radio(painter: QtGui.QPainter, item: dict[str, Any], value):
+    """Stepped 1D selector (Touch OSC Radio)."""
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    axis = _deadzone(_axis(value), style)
+    if style.get("invert_display"):
+        axis = -axis
+    steps = max(2, int(style.get("radio_steps") or 5))
+    idx = int(round((axis + 1.0) / 2.0 * (steps - 1)))
+    idx = max(0, min(steps - 1, idx))
+    vertical = (style.get("orientation") or "horizontal").casefold() == "vertical"
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    gap = 3.0
+    if vertical:
+        cell_h = (rect.height() - gap * (steps - 1)) / steps
+        for i in range(steps):
+            cell = QtCore.QRectF(rect.x(), rect.y() + i * (cell_h + gap), rect.width(), cell_h)
+            on = i == (steps - 1 - idx)
+            painter.setPen(_pen(style.get("border_on") if on else style.get("border"), style.get("border_width") or 1.5))
+            painter.setBrush(qcolor(style.get("fill_on") if on else style.get("fill"), "#121826"))
+            painter.drawRoundedRect(cell, 3, 3)
+    else:
+        cell_w = (rect.width() - gap * (steps - 1)) / steps
+        for i in range(steps):
+            cell = QtCore.QRectF(rect.x() + i * (cell_w + gap), rect.y(), cell_w, rect.height())
+            on = i == idx
+            painter.setPen(_pen(style.get("border_on") if on else style.get("border"), style.get("border_width") or 1.5))
+            painter.setBrush(qcolor(style.get("fill_on") if on else style.get("fill"), "#121826"))
+            painter.drawRoundedRect(cell, 3, 3)
+    _caption(painter, item, rect, vertical)
+    painter.restore()
+
+
+def paint_axis_fader(painter: QtGui.QPainter, item: dict[str, Any], value):
+    """Touch OSC fader: ladder track, value fill up to the thumb, sliding thumb."""
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    axis = _deadzone(_axis(value), style)
+    if style.get("invert_display"):
+        axis = -axis
+    vertical = (style.get("orientation") or "vertical").casefold() != "horizontal"
+    steps = max(3, int(style.get("radio_steps") or 8))
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    radius = float(style.get("corner_radius") or 4)
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    painter.setBrush(qcolor(style.get("fill") or style.get("track"), "#121826"))
+    painter.drawRoundedRect(rect, radius, radius)
+    inner = rect.adjusted(3, 3, -3, -3)
+    t = (axis + 1.0) / 2.0
+    painter.setClipPath(_rounded(rect, radius))
+    if vertical:
+        thumb_h = max(8.0, float(style.get("indicator_size") or 0) or (inner.height() / steps))
+        thumb_h = min(thumb_h, inner.height() * 0.45)
+        travel = max(0.0, inner.height() - thumb_h)
+        y = inner.bottom() - thumb_h - t * travel
+        thumb = QtCore.QRectF(inner.x(), y, inner.width(), thumb_h)
+        fill_h = max(0.0, inner.bottom() - thumb.bottom())
+        filled = QtCore.QRectF(inner.x(), thumb.bottom(), inner.width(), fill_h)
+    else:
+        thumb_w = max(8.0, float(style.get("indicator_size") or 0) or (inner.width() / steps))
+        thumb_w = min(thumb_w, inner.width() * 0.45)
+        travel = max(0.0, inner.width() - thumb_w)
+        x = inner.left() + t * travel
+        thumb = QtCore.QRectF(x, inner.y(), thumb_w, inner.height())
+        filled = QtCore.QRectF(inner.x(), inner.y(), max(0.0, thumb.left() - inner.left()), inner.height())
+    painter.setPen(QtCore.Qt.NoPen)
+    painter.setBrush(qcolor(style.get("fill_bar"), "#ff6b35"))
+    painter.drawRect(filled)
+    painter.setPen(_pen(style.get("grid"), style.get("grid_width") or 1.2))
+    if vertical:
+        for i in range(1, steps):
+            gy = inner.top() + inner.height() * (i / steps)
+            painter.drawLine(QtCore.QPointF(inner.left(), gy), QtCore.QPointF(inner.right(), gy))
+    else:
+        for i in range(1, steps):
+            gx = inner.left() + inner.width() * (i / steps)
+            painter.drawLine(QtCore.QPointF(gx, inner.top()), QtCore.QPointF(gx, inner.bottom()))
+    painter.setPen(QtCore.Qt.NoPen)
+    painter.setBrush(qcolor(style.get("fill_on") or style.get("indicator"), "#ff5a3c"))
+    painter.drawRect(thumb)
+    painter.setClipping(False)
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    painter.setBrush(QtCore.Qt.NoBrush)
+    painter.drawRoundedRect(rect, radius, radius)
+    _caption(painter, item, rect, vertical)
+    painter.restore()
+
+
+def paint_axis_radial(painter: QtGui.QPainter, item: dict[str, Any], value):
+    """Touch OSC radial: 270° arc with ticks and value fill."""
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    axis = _deadzone(_axis(value), style)
+    if style.get("invert_display"):
+        axis = -axis
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    side = min(rect.width(), rect.height())
+    circle = QtCore.QRectF(rect.center().x() - side / 2, rect.center().y() - side / 2, side, side)
+    track = circle.adjusted(12, 12, -12, -12)
+    width = max(8.0, float(style.get("needle_width") or 14))
+    start = 225 * 16
+    span = -270 * 16
+    painter.setBrush(QtCore.Qt.NoBrush)
+    painter.setPen(_pen(style.get("track") or style.get("fill"), width))
+    painter.drawArc(track, start, span)
+    filled = int(-270 * ((axis + 1) / 2) * 16)
+    painter.setPen(_pen(style.get("fill_bar") or style.get("indicator"), width))
+    painter.drawArc(track, start, filled)
+    border_w = float(style.get("border_width") or 2)
+    if border_w > 0:
+        cx_track, cy_track = track.center().x(), track.center().y()
+        track_r = min(track.width(), track.height()) / 2.0
+        outer_r = track_r + width / 2.0
+        inner_r_track = max(1.0, track_r - width / 2.0)
+        painter.setPen(_pen(style.get("border"), border_w))
+        painter.drawArc(QtCore.QRectF(cx_track - outer_r, cy_track - outer_r, outer_r * 2, outer_r * 2), start, span)
+        painter.drawArc(QtCore.QRectF(cx_track - inner_r_track, cy_track - inner_r_track, inner_r_track * 2, inner_r_track * 2), start, span)
+        for deg in (225.0, -45.0):
+            rad = math.radians(deg)
+            c, s = math.cos(rad), math.sin(rad)
+            painter.drawLine(
+                QtCore.QPointF(cx_track + c * inner_r_track, cy_track - s * inner_r_track),
+                QtCore.QPointF(cx_track + c * outer_r, cy_track - s * outer_r),
+            )
+    ticks = max(2, int(style.get("radio_steps") or 11))
+    painter.setPen(_pen(style.get("grid") or style.get("border"), 1.5))
+    cx, cy = circle.center().x(), circle.center().y()
+    outer = side / 2 - 2
+    inner_r = side / 2 - width - 10
+    for i in range(ticks):
+        t = i / (ticks - 1)
+        angle = math.radians(225 - 270 * t)
+        painter.drawLine(
+            QtCore.QPointF(cx + math.cos(angle) * inner_r, cy - math.sin(angle) * inner_r),
+            QtCore.QPointF(cx + math.cos(angle) * outer, cy - math.sin(angle) * outer),
+        )
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def _donut_slice(cx: float, cy: float, inner_r: float, outer_r: float, start_deg: float, span_deg: float) -> QtGui.QPainterPath:
+    path = QtGui.QPainterPath()
+    outer = QtCore.QRectF(cx - outer_r, cy - outer_r, outer_r * 2, outer_r * 2)
+    inner = QtCore.QRectF(cx - inner_r, cy - inner_r, inner_r * 2, inner_r * 2)
+    path.arcMoveTo(outer, start_deg)
+    path.arcTo(outer, start_deg, span_deg)
+    path.arcTo(inner, start_deg + span_deg, -span_deg)
+    path.closeSubpath()
+    return path
+
+
+def paint_axis_encoder(painter: QtGui.QPainter, item: dict[str, Any], value):
+    """Touch OSC encoder: full donut with ticks and one moving highlighted wedge."""
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    axis = _deadzone(_axis(value), style)
+    if style.get("invert_display"):
+        axis = -axis
+    ticks = max(4, int(style.get("radio_steps") or 16))
+    idx = int(round((axis + 1.0) / 2.0 * (ticks - 1)))
+    idx = max(0, min(ticks - 1, idx))
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    side = min(rect.width(), rect.height())
+    cx, cy = rect.center().x(), rect.center().y()
+    outer_r = side / 2 - 2
+    ring_w = float(style.get("needle_width") or 0)
+    if ring_w >= 8:
+        inner_r = max(outer_r * 0.22, outer_r - ring_w)
+    else:
+        inner_r = outer_r * 0.48
+    span = 360.0 / ticks
+    dim = qcolor(style.get("fill") or style.get("track"), "#121826")
+    lit = qcolor(style.get("fill_on") or style.get("indicator") or style.get("fill_bar"), "#ff5a3c")
+    painter.setPen(QtCore.Qt.NoPen)
+    for i in range(ticks):
+        painter.setBrush(lit if i == idx else dim)
+        # Qt 0° = 3 o'clock, positive CCW; start at 12 o'clock and walk clockwise.
+        start = 90.0 - i * span
+        painter.drawPath(_donut_slice(cx, cy, inner_r, outer_r, start, -span))
+    painter.setPen(_pen(style.get("grid") or style.get("border"), style.get("grid_width") or 1.2))
+    inset = 1.0
+    for i in range(ticks):
+        rad = math.radians(90.0 - i * span)
+        c, s = math.cos(rad), math.sin(rad)
+        painter.drawLine(
+            QtCore.QPointF(cx + c * (inner_r + inset), cy - s * (inner_r + inset)),
+            QtCore.QPointF(cx + c * (outer_r - inset), cy - s * (outer_r - inset)),
+        )
+    border_w = float(style.get("border_width") or 2)
+    painter.setBrush(QtCore.Qt.NoBrush)
+    painter.setPen(_pen(style.get("border"), border_w))
+    painter.drawEllipse(QtCore.QPointF(cx, cy), outer_r, outer_r)
+    painter.drawEllipse(QtCore.QPointF(cx, cy), inner_r, inner_r)
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def paint_axis_dial(painter: QtGui.QPainter, item: dict[str, Any], value):
+    paint_axis_radial(painter, item, value)
+
+
+def paint_axis_stick_square(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    x, y = _xy(value)
+    x, y = _deadzone(x, style), _deadzone(y, style)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    painter.setBrush(qcolor(style.get("fill"), "#121826"))
+    try:
+        radius = max(0.0, float(style.get("corner_radius")))
+    except (TypeError, ValueError):
+        radius = 6.0
+    painter.drawRoundedRect(rect, radius, radius)
+    inner = _inner_rect(rect, style)
+    inset = max(0.5, float(style.get("border_width") or 2) * 0.5)
+    clip = QtGui.QPainterPath()
+    clip.addRoundedRect(inner, max(0.0, radius - inset), max(0.0, radius - inset))
+    painter.setClipPath(clip)
+    _draw_square_grid(painter, inner, style)
+    _draw_crosshairs(painter, inner, style)
+    cx = inner.center().x() + x * (inner.width() / 2)
+    cy = inner.center().y() + y * (inner.height() / 2)
+    _draw_dot_crosshair(painter, inner, cx, cy, style)
+    _indicator(painter, QtCore.QPointF(cx, cy), style)
+    painter.setClipping(False)
+    _draw_axis_labels(painter, item, rect)
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def paint_axis_stick_circle(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    x, y = _xy(value)
+    x, y = _deadzone(x, style), _deadzone(y, style)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    side = min(rect.width(), rect.height())
+    circle = QtCore.QRectF(rect.center().x() - side / 2, rect.center().y() - side / 2, side, side)
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    painter.setBrush(qcolor(style.get("fill"), "#121826"))
+    painter.drawEllipse(circle)
+    radius = min(circle.width(), circle.height()) / 2.0
+    _draw_angle_lines(painter, circle.center(), radius, style)
+    _draw_ring_grid(painter, circle, style, int(style.get("ring_count") or 2))
+    _draw_crosshairs(painter, circle, style)
+    cx = circle.center().x() + x * radius
+    cy = circle.center().y() + y * radius
+    _draw_dot_crosshair(painter, circle, cx, cy, style, circular=True)
+    _indicator(painter, QtCore.QPointF(cx, cy), style)
+    _draw_axis_labels(painter, item, rect)
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def paint_axis_crosshair(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    x, y = _xy(value)
+    x, y = _deadzone(x, style), _deadzone(y, style)
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    side = min(rect.width(), rect.height())
+    circle = QtCore.QRectF(rect.center().x() - side / 2, rect.center().y() - side / 2, side, side)
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 1.5))
+    painter.setBrush(qcolor(style.get("fill"), "#0a1220"))
+    painter.drawEllipse(circle)
+    radius = min(circle.width(), circle.height()) / 2.0
+    _draw_angle_lines(painter, circle.center(), radius, style)
+    _draw_ring_grid(painter, circle, style, int(style.get("ring_count") or 3))
+    _draw_crosshairs(painter, circle, style)
+    origin = circle.center()
+    travel = max(8.0, radius - 2)
+    cx = origin.x() + x * travel
+    cy = origin.y() + y * travel
+    _draw_dot_crosshair(painter, circle, cx, cy, style, circular=True)
+    dist = math.hypot(cx - origin.x(), cy - origin.y())
+    painter.setBrush(QtCore.Qt.NoBrush)
+    painter.setPen(_pen(style.get("indicator"), max(1.5, float(style.get("needle_width") or 2))))
+    if dist > 2:
+        painter.drawEllipse(origin, dist, dist)
+    painter.drawLine(origin, QtCore.QPointF(cx, cy))
+    painter.setPen(QtCore.Qt.NoPen)
+    painter.setBrush(qcolor(style.get("indicator"), "#ff5a3c"))
+    painter.drawEllipse(origin, 2.5, 2.5)
+    _indicator(painter, QtCore.QPointF(cx, cy), style)
+    _draw_label(painter, item, rect)
+    painter.restore()
+
+
+def _hat_plus(painter: QtGui.QPainter, cx: float, cy: float, arm: float, thickness: float):
+    painter.drawRoundedRect(QtCore.QRectF(cx - thickness / 2, cy - arm * 2, thickness, arm * 4), 4, 4)
+    painter.drawRoundedRect(QtCore.QRectF(cx - arm * 2, cy - thickness / 2, arm * 4, thickness), 4, 4)
+
+
+def paint_hat(painter: QtGui.QPainter, item: dict[str, Any], value):
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    x, y = _xy(value)
+    eight = int(style.get("hat_positions") or 4) >= 8
+    painter.save()
+    painter.setOpacity(_opacity(style))
+    painter.setPen(_pen(style.get("border"), style.get("border_width") or 2))
+    painter.setBrush(qcolor(style.get("fill"), "#121826"))
+    radius = float(style.get("corner_radius") or 8)
+    painter.drawRoundedRect(rect, radius, radius)
+    cx, cy = rect.center().x(), rect.center().y()
+    arm = min(rect.width(), rect.height()) * 0.18
+    thickness = min(rect.width(), rect.height()) * (0.14 + 0.04 * float(style.get("grid_width") or 1))
+    painter.setPen(QtCore.Qt.NoPen)
+    painter.setBrush(qcolor(style.get("crosshair"), "#5a6a84"))
+    _hat_plus(painter, cx, cy, arm, thickness)
+    if eight:
+        painter.save()
+        painter.translate(cx, cy)
+        painter.rotate(45)
+        _hat_plus(painter, 0, 0, arm * 0.92, thickness * 0.85)
+        painter.restore()
+    nx, ny = 0, 0
+    if abs(x) > 0.15 or abs(y) > 0.15:
+        if eight:
+            nx = 0 if abs(x) < 0.15 else (1 if x > 0 else -1)
+            ny = 0 if abs(y) < 0.15 else (1 if y > 0 else -1)
+        elif abs(x) >= abs(y):
+            nx = 1 if x > 0 else -1
+        else:
+            ny = 1 if y > 0 else -1
+    if nx or ny:
+        length = math.hypot(nx, ny) or 1.0
+        dist = arm * 1.45
+        px = cx + (nx / length) * dist
+        py = cy - (ny / length) * dist
+        color = qcolor(style.get("fill_on") or style.get("indicator"), "#ff6b35")
+    else:
+        px, py = cx, cy
+        color = qcolor(style.get("indicator"), "#ff5a3c")
+    size = float(style.get("indicator_size") or 12) * 0.45
+    painter.setBrush(color)
+    painter.drawEllipse(QtCore.QPointF(px, py), size, size)
+    _draw_axis_labels(painter, item, rect)
+    painter.restore()
+
+
+_PAINTERS = {
+    "axis_bar": paint_axis_bar,
+    "axis_radio": paint_axis_radio,
+    "axis_fader": paint_axis_fader,
+    "axis_radial": paint_axis_radial,
+    "axis_encoder": paint_axis_encoder,
+    "axis_dial": paint_axis_radial,
+    "axis_stick_square": paint_axis_stick_square,
+    "axis_stick_circle": paint_axis_stick_circle,
+    "axis_crosshair": paint_axis_crosshair,
+    "button": paint_button,
+    "hat": paint_hat,
+    "label": paint_label,
+    "shape": paint_shape,
+    "panel": paint_shape,
+    "image": paint_image,
+    "streamdeck": paint_streamdeck,
+}
+
+
+def paint_widget(painter: QtGui.QPainter, item: dict[str, Any], value):
+    if not item.get("visible", True):
+        return
+    fn = _PAINTERS.get(item.get("type"), paint_button)
+    fn(painter, item, value)
+
+
+def _math_angle_deg(px: float, py: float, cx: float, cy: float) -> float:
+    """0° = east, counter-clockwise, Y up (matches paint_axis_radial / encoder)."""
+    return math.degrees(math.atan2(-(py - cy), px - cx))
+
+
+def _undo_invert_display(item: dict[str, Any], axis: float) -> float:
+    if (item.get("style") or {}).get("invert_display"):
+        return -axis
+    return axis
+
+
+def value_from_point(item: dict[str, Any], x: float, y: float):
+    """Map a scene point onto the value the widget would display (before binding invert)."""
+    widget_type = item.get("type")
+    style = item.get("style") or {}
+    rect = widget_rect(item)
+    if widget_type in ("label", "panel", "shape", "image", "streamdeck", "button"):
+        return None
+    if widget_type == "hat":
+        cx, cy = rect.center().x(), rect.center().y()
+        dx = x - cx
+        dy = cy - y
+        dead = min(rect.width(), rect.height()) * 0.18
+        if math.hypot(dx, dy) < dead:
+            return (0, 0)
+        eight = int(style.get("hat_positions") or 4) >= 8
+        if eight:
+            nx = 0 if abs(dx) < dead * 0.55 else (1 if dx > 0 else -1)
+            ny = 0 if abs(dy) < dead * 0.55 else (1 if dy > 0 else -1)
+            if nx == 0 and ny == 0:
+                if abs(dx) >= abs(dy):
+                    nx = 1 if dx > 0 else -1
+                else:
+                    ny = 1 if dy > 0 else -1
+            return (nx, ny)
+        if abs(dx) >= abs(dy):
+            return (1 if dx > 0 else -1, 0)
+        return (0, 1 if dy > 0 else -1)
+    if widget_type in ("axis_stick_square", "axis_stick_circle", "axis_crosshair"):
+        if widget_type == "axis_stick_square":
+            inner = _inner_rect(rect, style)
+            hw = max(1.0, inner.width() / 2.0)
+            hh = max(1.0, inner.height() / 2.0)
+            ax = _clamp((x - inner.center().x()) / hw)
+            ay = _clamp((y - inner.center().y()) / hh)
+        else:
+            side = min(rect.width(), rect.height())
+            radius = max(1.0, side / 2.0)
+            if widget_type == "axis_crosshair":
+                radius = max(8.0, radius - 2)
+            ax = (x - rect.center().x()) / radius
+            ay = (y - rect.center().y()) / radius
+            mag = math.hypot(ax, ay)
+            if mag > 1.0:
+                ax /= mag
+                ay /= mag
+        return (_clamp(ax), _clamp(ay))
+    if widget_type == "axis_radio":
+        steps = max(2, int(style.get("radio_steps") or 5))
+        vertical = (style.get("orientation") or "horizontal").casefold() == "vertical"
+        if vertical:
+            t = (y - rect.y()) / max(1.0, rect.height())
+            cell = max(0, min(steps - 1, int(t * steps)))
+            idx = steps - 1 - cell
+        else:
+            t = (x - rect.x()) / max(1.0, rect.width())
+            idx = max(0, min(steps - 1, int(t * steps)))
+        axis = _clamp(-1.0 + 2.0 * idx / (steps - 1))
+        return _undo_invert_display(item, axis)
+    if widget_type == "axis_encoder":
+        ticks = max(4, int(style.get("radio_steps") or 16))
+        cx, cy = rect.center().x(), rect.center().y()
+        ang = _math_angle_deg(x, y, cx, cy)
+        span = 360.0 / ticks
+        cw = (90.0 - ang) % 360.0
+        idx = int(cw / span) % ticks
+        axis = _clamp(-1.0 + 2.0 * idx / (ticks - 1))
+        return _undo_invert_display(item, axis)
+    if widget_type in ("axis_radial", "axis_dial"):
+        cx, cy = rect.center().x(), rect.center().y()
+        ang = _math_angle_deg(x, y, cx, cy)
+        rel = (225.0 - ang) % 360.0
+        if rel <= 270.0:
+            t = rel / 270.0
+        else:
+            t = 0.0 if rel >= 315.0 else 1.0
+        return _undo_invert_display(item, _clamp(t * 2.0 - 1.0))
+    inner = _inner_rect(rect, style)
+    if widget_type == "axis_fader":
+        inner = rect.adjusted(3, 3, -3, -3)
+    vertical = (style.get("orientation") or "vertical").casefold() != "horizontal"
+    if vertical:
+        t = (inner.bottom() - y) / max(1.0, inner.height())
+    else:
+        t = (x - inner.left()) / max(1.0, inner.width())
+    return _undo_invert_display(item, _clamp(t * 2.0 - 1.0))
+
+
+_bg_image_cache: dict[tuple, QtGui.QPixmap] = {}
+
+
+def _fill_checkerboard(painter: QtGui.QPainter, rect: QtCore.QRect, tile: int = 8):
+    light = QtGui.QColor("#3a4250")
+    dark = QtGui.QColor("#2a3140")
+    painter.fillRect(rect, dark)
+    y = rect.y()
+    while y < rect.y() + rect.height():
+        x = rect.x()
+        row = ((y - rect.y()) // tile) & 1
+        while x < rect.x() + rect.width():
+            col = ((x - rect.x()) // tile) & 1
+            if (row + col) & 1:
+                painter.fillRect(x, y, tile, tile, light)
+            x += tile
+        y += tile
+
+
+def paint_background(
+    painter: QtGui.QPainter,
+    canvas: dict[str, Any],
+    rect: QtCore.QRect,
+    preview: bool = False,
+    fallback_chroma: bool = True,
+):
+    mode = normalize_background_mode(canvas.get("background_mode"))
+    if is_onscreen_mode(canvas):
+        if preview:
+            painter.fillRect(rect, QtGui.QColor("#1b2230"))
+        return
+    if mode == "image":
+        path = canvas.get("image_path") or ""
+        if path:
+            key = (path, rect.width(), rect.height())
+            pixmap = _bg_image_cache.get(key)
+            if pixmap is None or pixmap.isNull():
+                loaded = QtGui.QPixmap(path)
+                if not loaded.isNull():
+                    pixmap = loaded.scaled(rect.size(), QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.SmoothTransformation)
+                    _bg_image_cache.clear()
+                    _bg_image_cache[key] = pixmap
+            if pixmap is not None and not pixmap.isNull():
+                painter.drawPixmap(rect, pixmap)
+                return
+    if not fallback_chroma:
+        return
+    color = chroma_fill_color(canvas)
+    if preview and color.alpha() < 255:
+        _fill_checkerboard(painter, rect)
+        if color.alpha() > 0:
+            painter.fillRect(rect, color)
+        return
+    painter.fillRect(rect, color)

--- a/gremlin/ui/ui_common.py
+++ b/gremlin/ui/ui_common.py
@@ -3922,6 +3922,7 @@ class InputListenerWidget(QBoxFrame):
 
         self._close_on_key = not any_button and not (InputType.Keyboard in event_types or InputType.KeyboardLatched in event_types)
         self._esc_key = key_from_name("esc")
+        self._hooked = False
 
         # Create and configure the ui overlay
         self.main_layout = QtWidgets.QVBoxLayout(self)
@@ -3951,7 +3952,7 @@ class InputListenerWidget(QBoxFrame):
             self.main_layout.addWidget(widget, alignment=QtCore.Qt.AlignmentFlag.AlignHCenter)
             msg = """<center>Press Ok to accept, Cancel to quit.</center>"""
         else:
-            msg = f"""<center>Please press the desired {self._valid_event_types_string()}.<br/><br/>Hold ESC{"" if self._close_on_key else " for one second"} to abort.</center>"""
+            msg = f"""<center>Please press the desired {self._valid_event_types_string()}.<br/><br/>Press ESC{"" if self._close_on_key else " and hold for one second"} to abort.</center>"""
 
         label.setText(msg)
 
@@ -3959,7 +3960,8 @@ class InputListenerWidget(QBoxFrame):
         gremlin.shared_state.push_suspend_ui_keyinput()  # prevent UI hotkeys from working
 
         self.setWindowModality(QtCore.Qt.ApplicationModal)
-        self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.WindowStaysOnTopHint)
+        self.setFocusPolicy(QtCore.Qt.StrongFocus)
         self.setFrameStyle(QtWidgets.QFrame.Plain | QtWidgets.QFrame.Box)
         palette = QtGui.QPalette()
         palette.setColor(QtGui.QPalette.ColorRole.Window, QtGui.QColorConstants.DarkGray)
@@ -3976,19 +3978,73 @@ class InputListenerWidget(QBoxFrame):
             mh = gremlin.windows_event_hook.MouseHook()
             mh.registerMouseMove(self._mouse_move_cb)
             mh.register(self._mouse_event_cb)  # trap clicks
+        self._hooked = True
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.raise_()
+        self.activateWindow()
+        self.setFocus(QtCore.Qt.OtherFocusReason)
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent):
+        if event.key() == QtCore.Qt.Key_Escape:
+            self._abort_now()
+            event.accept()
+            return
+        super().keyPressEvent(event)
 
     def unhook(self):
         """called on widget destruction"""
-
+        if not self._hooked:
+            return
+        self._hooked = False
         el = gremlin.event_handler.EventListener()
-        el.keyboard_event.disconnect(self._kb_event_cb)
-        el.joystick_event_ui.disconnect(self._joy_event_cb)
+        try:
+            el.keyboard_event.disconnect(self._kb_event_cb)
+        except Exception:
+            pass
+        try:
+            el.joystick_event_ui.disconnect(self._joy_event_cb)
+        except Exception:
+            pass
 
         if self._listen_mouse:
             # unhook mouse callbacks
             mh = gremlin.windows_event_hook.MouseHook()
             mh.unregisterMouseMove(self._mouse_move_cb)
             mh.unregister(self._mouse_event_cb)
+
+    def _is_escape(self, event=None, key=None) -> bool:
+        """True if this is Escape. Key objects are copies, so identity comparison does not work."""
+        if event is not None:
+            if int(getattr(event, "virtual_code", 0) or 0) == 0x1B:
+                return True
+            ident = getattr(event, "identifier", None)
+            if isinstance(ident, (tuple, list)) and ident and int(ident[0] or 0) == 0x01:
+                return True
+        if key is not None:
+            if int(getattr(key, "virtual_code", 0) or 0) == 0x1B:
+                return True
+            if int(getattr(key, "scan_code", 0) or 0) == 0x01:
+                return True
+            name = (getattr(key, "name", None) or getattr(key, "lookup_name", None) or "").replace(" ", "").casefold()
+            if name in ("esc", "escape"):
+                return True
+            if self._esc_key is not None:
+                kt = getattr(key, "key_tuple", None)
+                et = getattr(self._esc_key, "key_tuple", None)
+                if kt is not None and kt == et:
+                    return True
+        return False
+
+    def _abort_now(self):
+        self._aborting = True
+        if self._abort_timer:
+            try:
+                self._abort_timer.cancel()
+            except Exception:
+                pass
+        self.close()
 
     @property
     def accepted(self) -> bool:
@@ -4054,6 +4110,7 @@ class InputListenerWidget(QBoxFrame):
 
         if self._aborting:
             self.close()
+            return
 
         key = gremlin.keyboard.KeyMap.from_event(event)
 
@@ -4063,9 +4120,23 @@ class InputListenerWidget(QBoxFrame):
         if verbose:
             syslog.info(f"LISTEN: Keyboard event: {event} {key}")
 
+        if self._is_escape(event, key):
+            if self._close_on_key:
+                self._abort_now()
+                return
+            if event.is_pressed:
+                if self._abort_timer and not self._abort_timer.is_alive():
+                    self._abort_timer.start()
+            else:
+                if self._abort_timer:
+                    try:
+                        self._abort_timer.cancel()
+                    except Exception:
+                        pass
+                    self._abort_timer = threading.Timer(1.0, self._abort_request)
+            return
+
         if self._close_on_key:
-            if key == self._esc_key:
-                self.close()
             return  # ignore keys otherwise
 
         if not event.is_pressed:
@@ -4079,23 +4150,16 @@ class InputListenerWidget(QBoxFrame):
 
         if not self._multi_keys:
             # single key mode
-            if key == self._esc_key:
-                if not self._abort_timer.is_alive():
-                    self._abort_timer.start()
+            if not self._return_kb_event:
+                self.item_selected.emit([key])
             else:
-                if not self._return_kb_event:
-                    self.item_selected.emit([key])
-                else:
-                    self.item_selected.emit(event)
+                self.item_selected.emit(event)
 
-                self.selection = [key]
-                self._accepted = True
+            self.selection = [key]
+            self._accepted = True
+            if self._abort_timer:
                 self._abort_timer.cancel()
-                self.close()
-
-            if not event.is_pressed and key == self._esc_key:
-                self._abort_timer.cancel()
-                self._abort_timer = threading.Timer(1.0, self._abort_request)
+            self.close()
 
         else:
             # multi-key mode
@@ -4183,24 +4247,15 @@ class InputListenerWidget(QBoxFrame):
 
     def closeEvent(self, evt):
         """Closes the overlay window."""
-
-        event_listener = gremlin.event_handler.EventListener()
-        event_listener.keyboard_event.disconnect(self._kb_event_cb)
-        if InputType.JoystickAxis in self._event_types or InputType.JoystickButton in self._event_types or InputType.JoystickHat in self._event_types:
-            event_listener.joystick_event.disconnect(self._joy_event_cb)
-        if self._listen_mouse:
-            # unhook mouse
-            mh = gremlin.windows_event_hook.MouseHook()
-            mh.unregister(self._mouse_event_cb)
-
-        # restore highlighting
+        if self._abort_timer:
+            try:
+                self._abort_timer.cancel()
+            except Exception:
+                pass
+        self.unhook()
         gremlin.shared_state.pop_suspend_highlighting()
         gremlin.shared_state.pop_suspend_ui_keyinput()
-
-        self.unhook()
         self.closed.emit(self._accepted)
-
-        # print ("input widget close")
         return super().closeEvent(evt)
 
     def _valid_event_types_string(self):

--- a/gremlin/ui/user_plugin_management.py
+++ b/gremlin/ui/user_plugin_management.py
@@ -207,6 +207,10 @@ class ModuleManagementController(QtCore.QObject):
             # if verbose:
             #     log.info(f"\t{str(var)}")
             if var.variable_type is not None:
+                if var.variable_type == PluginVariableType.Action:
+                    ui_element = var.create_ui_element(None)
+                    layout.addLayout(ui_element)
+                    continue
                 # Create basic profile variable instance if it does not exist
                 if not instance.has_variable(var.label):
                     profile_var = gremlin.base_profile.PluginVariable(instance)
@@ -329,6 +333,8 @@ class ModuleManagementController(QtCore.QObject):
             instance.parent.file_name
         )
         for var in variables:
+            if var.variable_type == PluginVariableType.Action:
+                continue
             ivar = instance.get_variable(var.label)
             ivar.name = var.label
             ivar.type = var.variable_type

--- a/gremlin/user_plugin.py
+++ b/gremlin/user_plugin.py
@@ -700,3 +700,31 @@ class SelectionVariable(AbstractVariable):
 
     def __str__(self):
         return f"SelectionVariable: description: {self.description} values: {self.options}"
+
+
+class ButtonVariable(AbstractVariable):
+    """Optional action button shown in the plugin instance configuration panel."""
+
+    def __init__(self, label, description, callback=None, is_optional=True):
+        super().__init__(label, description, gremlin.types.PluginVariableType.Action, is_optional=True)
+        self.value = None
+        self.callback = callback
+
+    def create_ui_element(self, value):
+        layout = QtWidgets.QGridLayout()
+        button = QtWidgets.QPushButton(self.label)
+        button.setToolTip(self.description)
+        button.clicked.connect(self._clicked)
+        layout.addWidget(button, 0, 0, 1, 2)
+        layout.setColumnStretch(1, 1)
+        return layout
+
+    def _clicked(self):
+        if callable(self.callback):
+            self.callback()
+
+    def _process_registry_value(self, value):
+        return None
+
+    def __str__(self):
+        return f"ButtonVariable: {self.label}"

--- a/gremlinEx.py
+++ b/gremlinEx.py
@@ -644,6 +644,8 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
             # plugins
             plugins = gremlin.shared_state.current_profile.plugins
             return {edit_mode: True} if len(plugins) > 0 else {}
+        elif device_guid == gremlin.shared_state.overlay_tab_guid:
+            return {}
         elif device_guid == gremlin.shared_state.keyboard_tab_guid:
             look_for_containers = False
 
@@ -750,6 +752,8 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
                     return TabDeviceType.OctaviIFR1
                 case DeviceType.StreamDeck:
                     return TabDeviceType.StreamDeck
+                case DeviceType.Overlay:
+                    return TabDeviceType.Overlay
 
             raise ValueError(f"Don't know how to handle type: [{device.device_type}]")
 
@@ -3430,6 +3434,34 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
                                 tab_device_list.append(device)
                                 index += 1
 
+                        case DeviceType.Overlay:
+                            try:
+                                device_guid = gremlin.util.normalize_guid(gremlin.shared_state.overlay_tab_guid)
+                                device = gremlin.joystick_handling.getDevice(device_guid)
+                                widget = self.getRegisteredWidget(device_guid)
+                                if not widget:
+                                    import gremlin.ui.obs_overlay as obs_overlay
+
+                                    manager = obs_overlay.OverlayManager()
+                                    widget = obs_overlay.OverlayDesignerWidget(
+                                        manager.scene,
+                                        overlay_manager=manager,
+                                    )
+                                    self.registerWidget(device_guid, widget)
+                                    self._overlay_device_guid = device_guid
+                                    widget.data = (
+                                        TabDeviceType.Overlay,
+                                        device_guid,
+                                        index,
+                                    )
+                                if device not in tab_device_list:
+                                    self._add_tab(device, TabDeviceType.Overlay)
+                                    tab_device_list.append(device)
+                                    index += 1
+                            except Exception as err:
+                                syslog.error(f"DEVICE TABS: Overlay tab failed: {err}")
+                                syslog.error(traceback.format_exc())
+
             self._reindex_tabs()
 
             el = gremlin.event_handler.EventListener()
@@ -3978,8 +4010,9 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
                         (
                             gremlin.shared_state.settings_tab_guid,
                             gremlin.shared_state.plugins_tab_guid,
+                            gremlin.shared_state.overlay_tab_guid,
                         ),
-                    )  # settings and plugins tabs don't have inputs
+                    )  # settings, plugins, and overlay tabs don't have inputs
 
                     if verbose:
                         syslog.info(
@@ -4318,6 +4351,9 @@ class GremlinUi(gremlin.ui.ui_common.QRememberMainWindow):
 
         # add the user plugin tab
         guid_list.append(self._find_tab_data_guid(gremlin.shared_state.plugins_tab_guid))
+
+        # add the overlay designer tab
+        guid_list.append(self._find_tab_data_guid(gremlin.shared_state.overlay_tab_guid))
 
         # move the tabs to the correct location
         tab_data = [self.ui.devices_tab_header_widget.tabData(index) for index in range(self.ui.devices_tab_header_widget.count())]

--- a/gremlinEx.spec
+++ b/gremlinEx.spec
@@ -38,7 +38,8 @@ for root, _, files in os.walk("icons"):
 added_files = [
     ("about", "about"),
     ("doc", "doc"),
-    ("icons","icons")
+    ("icons","icons"),
+    ("gremlin/ui/streamdeck_icon_library", "gremlin/ui/streamdeck_icon_library"),
 ]
 
 added_files.extend(action_plugins_files)
@@ -46,17 +47,21 @@ added_files.extend(icon_files)
 added_files.extend(container_plugins_files)
 added_files.extend(doc_files)
 added_files.extend(xml_files)
-added_binaries = [
+_binary_candidates = [
     ("vjoy/vJoyInterface.dll", "."),
     ("dill.dll", "."),
     ("vigem/ViGEmClient.dll", "."),
-    ("SimConnect.dll","."),
-    ("hidapi.dll","."),
-    ("ffmpeg/ffmpeg.exe","."),
-    ("ffmpeg/ffprobe.exe","."),
-
-
+    ("SimConnect.dll", "."),
+    ("hidapi.dll", "."),
+    ("ffmpeg/ffmpeg.exe", "."),
+    ("ffmpeg/ffprobe.exe", "."),
 ]
+added_binaries = []
+for src, dest in _binary_candidates:
+    if os.path.exists(src):
+        added_binaries.append((src, dest))
+    else:
+        print(f"WARNING: skipping missing binary {src}")
 
 '''
 excludes=["torch",
@@ -96,7 +101,19 @@ a = Analysis(
         "pydub",
         "faster_whisper",
         "pycaw",
-        "pycountry"] +  collect_submodules('encodings'),
+        "pycountry",
+        "gremlin.ui.obs_overlay",
+        "gremlin.ui.obs_overlay.bindings",
+        "gremlin.ui.obs_overlay.designer",
+        "gremlin.ui.obs_overlay.inspector",
+        "gremlin.ui.obs_overlay.model",
+        "gremlin.ui.obs_overlay.overlay_window",
+        "gremlin.ui.obs_overlay.palettes",
+        "gremlin.ui.obs_overlay.shapes",
+        "gremlin.ui.obs_overlay.templates",
+        "gremlin.ui.obs_overlay.touch",
+        "gremlin.ui.obs_overlay.widgets",
+        ] +  collect_submodules('encodings'),
     hookspath=None,
     runtime_hooks=None,
     excludes=["torch",

--- a/user_plugins/obs_overlay.py
+++ b/user_plugins/obs_overlay.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; -*-
+#
+# Optional overlay helper plugin for Joystick Gremlin Ex.
+# The Overlay tab is always available. This plugin only adds a button
+# that switches to that tab, plus an extra profile-start toggle for
+# profiles that already used the plugin.
+#
+
+from gremlin.input_devices import gremlin_start, gremlin_stop
+from gremlin.user_plugin import BoolVariable, ButtonVariable
+
+
+def _launch_designer():
+    import gremlin.ui.obs_overlay as overlay
+
+    overlay.launch_designer()
+
+
+launch = ButtonVariable(
+    "Open Overlay tab",
+    "Switch to the Overlay tab for the current profile. Layouts are stored with that profile.",
+    callback=_launch_designer,
+)
+
+auto_show = BoolVariable(
+    "Show overlay when profile starts",
+    "Also open the overlay when this plugin instance starts. Prefer the Overlay tab option of the same name.",
+    False,
+    is_optional=True,
+)
+
+
+@gremlin_start()
+def on_start():
+    if auto_show.value:
+        from PySide6 import QtCore
+
+        def _open():
+            try:
+                import gremlin.ui.obs_overlay as overlay
+
+                overlay.show_overlay(auto=True)
+            except Exception:
+                pass
+
+        QtCore.QTimer.singleShot(0, _open)
+
+
+@gremlin_stop()
+def on_stop():
+    if not auto_show.value:
+        return
+    try:
+        import gremlin.ui.obs_overlay as overlay
+
+        overlay.hide_overlay()
+    except Exception:
+        pass


### PR DESCRIPTION
﻿## Summary
- Adds a profile-scoped Overlay designer tab painted with Qt QPainter for OBS chromakey / on-screen HUD use.
- Includes touch interaction polish and related docs / plugin wiring.

## Test plan
- [ ] Open the Overlay tab, add widgets, save/reload the profile
- [ ] Confirm overlay.json is written next to the profile
- [ ] Toggle overlay visibility / chromakey-friendly background
- [ ] Verify Voice and other special tabs still appear normally
