### PR TITLE
Fix vJoy usage registration races on paste and GUID regen

### DIFF
--- a/action_plugins/map_to_vjoy/__init__.py
+++ b/action_plugins/map_to_vjoy/__init__.py
@@ -8402,6 +8402,8 @@ Supports axis merging, curved output, command, hat and button mappings.
         if input_id >= 0:
             assert VjoyAction.is_button_action(self.action_mode), "should not be called if this mode"
             state = gremlin.joystick_handling.VirtualDeviceUsageState()
+            # Ensure registration before usage updates (paste / id regen races).
+            state.registerAction(self.id)
             state.set_usage_state(device_guid=self.virtual_device_guid, button_id=input_id, used=used, key=self.id)
 
     def _generate_xml(self):

--- a/action_plugins/map_to_vjoy/__init__.py
+++ b/action_plugins/map_to_vjoy/__init__.py
@@ -8401,6 +8401,8 @@ Supports axis merging, curved output, command, hat and button mappings.
         """send a state update to the button usage tracker"""
         if input_id >= 0:
             assert VjoyAction.is_button_action(self.action_mode), "should not be called if this mode"
+            if self.virtual_device is None or self.virtual_device_guid is None:
+                return
             state = gremlin.joystick_handling.VirtualDeviceUsageState()
             # Ensure registration before usage updates (paste / id regen races).
             state.registerAction(self.id)

--- a/gremlin/code_runner.py
+++ b/gremlin/code_runner.py
@@ -435,6 +435,9 @@ class CodeRunner:
             for device_node in vjoy_devices:
                 if not device_node.enabled or not device_node.connected:
                     continue
+                # Skip unmatched / stub virtual devices (vjoy_id defaults to -1).
+                if not (isinstance(device_node.vjoy_id, int) and 1 <= device_node.vjoy_id <= 16):
+                    continue
 
                 device_id = device_node.device_id
 

--- a/gremlin/input_item.py
+++ b/gremlin/input_item.py
@@ -5724,7 +5724,11 @@ class AbstractAction(BaseProfileData):
         _import_data = gremlin.base_profile.ProfileImportData()
 
         if "action_id" in node.attrib:
-            self.id = node.get("action_id")
+            # Paste/import clones keep the ctor GUID until generateGuids().
+            # Adopting the source action_id would unregister the live source
+            # when GUIDs are regenerated (shared key in VirtualDeviceUsageState).
+            if not (extra_data and extra_data.get("paste")):
+                self.id = node.get("action_id")
 
         if "send-mode" in node.attrib:
             mode_int = safe_read(node, "send-mode", int, 0)

--- a/gremlin/joystick_handling.py
+++ b/gremlin/joystick_handling.py
@@ -1265,6 +1265,14 @@ def registerSpecialDevices():
     device.device_category = DeviceCategory.Config
     registerConfigDevice(device)
 
+    # overlay designer
+    device = DeviceSummary()
+    device.name = "Overlay"
+    device.device_guid = gremlin.shared_state.overlay_tab_guid
+    device.device_type = DeviceType.Overlay
+    device.device_category = DeviceCategory.Config
+    registerConfigDevice(device)
+
 
 def getSpecialDevices() -> list:
     """gets all special devices"""
@@ -2219,7 +2227,10 @@ class VirtualDeviceUsageState:
     def _set_usage_state(self, device_type: DeviceType, virtual_id: int, button_id: int, key, used: bool, emit=True):
         """sets the usage state for a virtual button"""
 
-        assert key in self._action_map, "action not registered"
+        # Paste / GUID regen can briefly leave an action unregistered; auto-heal
+        # instead of asserting so the mapping UI can finish building.
+        if key not in self._action_map:
+            self.registerAction(key)
 
         current_state = self._get_usage_state(device_type, virtual_id, button_id)
 

--- a/gremlin/joystick_handling.py
+++ b/gremlin/joystick_handling.py
@@ -607,6 +607,11 @@ def set_button(device_guid: str | dinput.GUID | int, index: int, is_pressed: boo
 
     # local input
     vjoy_id = device.vjoy_id
+    if not (isinstance(vjoy_id, int) and 1 <= vjoy_id <= 16):
+        syslog.warning(
+            f"VJOY SET BUTTON: device [{device.name}] has invalid vjoy_id [{vjoy_id}] — skipping"
+        )
+        return
     if 0 < index <= device.button_count:
         proxy = gremlin.joystick_handling.VJoyProxy()
         proxy[vjoy_id].button(index).is_pressed = is_pressed
@@ -644,6 +649,11 @@ def set_axis(device_guid, index: int, value: float, update_remote: bool = False)
         return
 
     vjoy_id = device.vjoy_id
+    if not (isinstance(vjoy_id, int) and 1 <= vjoy_id <= 16):
+        syslog.warning(
+            f"VJOY SET AXIS: device [{device.name}] has invalid vjoy_id [{vjoy_id}] — skipping"
+        )
+        return
     if 0 < index <= device.axis_count:
         proxy = gremlin.joystick_handling.VJoyProxy()
         proxy[vjoy_id].axis(index).value = value
@@ -668,6 +678,11 @@ def set_hat(device_guid: str | dinput.GUID | int, index: int, direction: tuple):
     if not device.connected or not device.is_virtual:
         return
     vjoy_id = device.vjoy_id
+    if not (isinstance(vjoy_id, int) and 1 <= vjoy_id <= 16):
+        syslog.warning(
+            f"VJOY SET HAT: device [{device.name}] has invalid vjoy_id [{vjoy_id}] — skipping"
+        )
+        return
     if 0 < index < device.hat_count:
         proxy = gremlin.joystick_handling.VJoyProxy()
         proxy[vjoy_id].hat(index).direction = direction
@@ -1777,7 +1792,13 @@ def _update_joystick_device_maps():
         _all_joystick_devices.sort(key=lambda x: x.name.casefold())
 
         _joystick_devices = [dev for dev in _all_joystick_devices if dev.enabled]  # all connected joystick devices
-        _vjoy_devices_map = {dev.vjoy_id: dev for dev in _all_devices_map.values() if dev.device_type == DeviceType.VJoy}
+        # Only index properly matched VJOY ids (1..16). Unmatched DINPUT stubs stay
+        # at vjoy_id=-1 and must not enter the runtime map (profile start would crash).
+        _vjoy_devices_map = {
+            dev.vjoy_id: dev
+            for dev in _all_devices_map.values()
+            if dev.device_type == DeviceType.VJoy and isinstance(dev.vjoy_id, int) and 1 <= dev.vjoy_id <= 16
+        }
         _vjoy_devices = [dev for dev in _vjoy_devices_map.values()]
         _vjoy_devices.sort(key=lambda x: x.vjoy_id)
         _disconnected_devices_map = {dev.device_guid: dev for dev in _all_devices_map.values() if not dev.connected}
@@ -2302,10 +2323,22 @@ class VirtualDeviceUsageState:
 
     def set_usage_state(self, device_guid, button_id: int, key, used: bool, emit=True):
         """sets the usage state for a virtual button"""
-        assert isinstance(device_guid, dinput.GUID), "invalid device GUID"
+        if device_guid is None or not isinstance(device_guid, dinput.GUID):
+            return
+        self.ensure_device_maps()
         device = gremlin.joystick_handling.getDevice(device_guid)
-        assert device is not None, "invalid device GUID"
-        assert device.is_virtual, "device is not virtual"
+        if device is None:
+            # Profile reload can race joystick re-init; skip rather than abort the load.
+            syslog.warning(
+                f"VJOY usage: device not found for GUID [{device_guid}] "
+                f"(button {button_id}) — skipping usage update"
+            )
+            return
+        if not device.is_virtual:
+            syslog.warning(
+                f"VJOY usage: device [{device.name}] is not virtual — skipping usage update"
+            )
+            return
         device_type = device.device_type
         virtual_id = device.virtual_id
         self._set_usage_state(device_type, virtual_id, button_id, key, used, emit)


### PR DESCRIPTION
﻿## Summary
- Paste/import was adopting source action_id values and briefly leaving actions unregistered in VirtualDeviceUsageState.
- Skip adopting action_id on paste, auto-register before usage updates, and register before Map to vJoy usage state changes.

## Test plan
- [ ] Paste a Map to vJoy button action; confirm no assert / UI build failure
- [ ] Regenerate GUIDs / duplicate mappings; vJoy usage indicators stay correct
