### PR TITLE
Skip Macro/State UI rebuilds while a profile is loading

### DIFF
--- a/action_plugins/macro/__init__.py
+++ b/action_plugins/macro/__init__.py
@@ -1211,7 +1211,14 @@ class MacroWidget(gremlin.input_item.AbstractActionWidget):
         self._populate_ui()
 
     def _update_state(self):
-        # update the sequence
+        # update the sequence — never rebuild Macro UI during profile load or
+        # off the UI thread (StateData.crud can fire while XML is parsed).
+        if gremlin.shared_state.profile_loading:
+            return
+        if not gremlin.util.is_ui_thread():
+            return
+        if not Shiboken.isValid(self):
+            return
         self._populate_ui()
 
     def _create_ui(self):

--- a/gremlin/ui/state_device.py
+++ b/gremlin/ui/state_device.py
@@ -1532,7 +1532,10 @@ class StateData:
         state = StateInputItem(key, value, description)
         self._data[key] = state
         self._id_map[state.id] = state
-        self.crud.emit()
+        # Skip UI refresh during profile XML load — MacroWidgets still listen
+        # to crud and would rebuild VJoy dropdowns on the worker thread.
+        if not gremlin.shared_state.profile_loading:
+            self.crud.emit()
         return state
 
     def update_key(self, state, old_name, new_name):
@@ -1544,7 +1547,8 @@ class StateData:
         # remove the old state AFTER updates or things referencing the old state won't find it
         if old_name in self._data:
             del self._data[old_name]
-        self.crud.emit()
+        if not gremlin.shared_state.profile_loading:
+            self.crud.emit()
 
     def _expression_changed(self, state):
         self.expression_changed.emit(state)
@@ -1586,7 +1590,7 @@ class StateData:
             self._data[data.key] = data
             self._id_map[data.id] = data
             self._sort()
-            if emit:
+            if emit and not gremlin.shared_state.profile_loading:
                 self.crud.emit()
 
     def _sort(self):
@@ -1769,7 +1773,8 @@ class StateData:
         if self._data:
             self._data.clear()
             self._id_map.clear()
-            self.crud.emit()
+            if not gremlin.shared_state.profile_loading:
+                self.crud.emit()
 
     def remove(self, state: StateInputItem | str):
 
@@ -1782,7 +1787,8 @@ class StateData:
             data.unhook()
             del self._data[key]
             del self._id_map[data.id]
-            self.crud.emit()
+            if not gremlin.shared_state.profile_loading:
+                self.crud.emit()
 
     def removeId(self, id: str):
         if id in self._id_map:


### PR DESCRIPTION
﻿## Summary
- StateData.crud was refreshing Macro widgets during XML load, including off the UI thread.
- Skip crud emit while profile_loading, and guard MacroWidget _update_state for load / non-UI thread / invalid widget.

## Test plan
- [ ] Load a large profile with States + Macro actions; no cross-thread parent warnings / Macro rebuild spam
- [ ] After load, editing States still refreshes Macro UI normally
