### PR TITLE
Refresh plugin is_optional and configure VirtualInput like PhysicalInput

### DIFF
--- a/gremlin/base_profile.py
+++ b/gremlin/base_profile.py
@@ -5954,6 +5954,10 @@ class PluginInstance:
                 return True
         for var in [var for var in self.variables.values() if not var.is_optional]:
             if not var.is_configured:
+                syslog.warn(
+                    f"Plugin instance '{self.name}' not configured: variable '{var.name}' "
+                    f"type={var.type} optional={var.is_optional} value={var.value}"
+                )
                 return False
         return True
 
@@ -6043,6 +6047,11 @@ class PluginVariable:
         if self.type is None or self.name is None:
             return False
         if self.type == PluginVariableType.PhysicalInput:
+            if self.value and "device_id" in self.value:
+                return self.value["device_id"] is not None
+            return False
+
+        if self.type == PluginVariableType.VirtualInput:
             if self.value and "device_id" in self.value:
                 return self.value["device_id"] is not None
             return False

--- a/gremlin/ui/user_plugin_management.py
+++ b/gremlin/ui/user_plugin_management.py
@@ -216,8 +216,10 @@ class ModuleManagementController(QtCore.QObject):
 
                 # Update profile variable properties if needed
                 profile_var = instance.get_variable(var.label)
+                # Always refresh optional flag from the Python definition so plugins
+                # can mark new PhysicalInputs optional without forcing a re-add.
+                profile_var.is_optional = bool(var.is_optional)
                 if profile_var.type is None:
-                    profile_var.is_optional = var.is_optional
                     profile_var.type = var.variable_type
                     profile_var.value = var.value
                     instance.set_variable(var.label, profile_var)


### PR DESCRIPTION
﻿## Summary
- Always refresh is_optional from the Python plugin definition so new optional inputs do not require removing/re-adding the instance.
- Treat VirtualInput is_configured the same as PhysicalInput (requires device_id).
- Log which required variable blocked configuration.

## Test plan
- [ ] Change a plugin variable to optional in script; reopen Plugins tab without re-adding instance
- [ ] VirtualInput variables require a device selection before the instance is considered configured
